### PR TITLE
Add Cursor Cloud Agent dev environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,22 @@
+{
+  "name": "Hitly",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "web",
+      "command": "yarn dev:web",
+      "description": "Marketing + docs site (@hitly/web) on http://localhost:3000"
+    },
+    {
+      "name": "app",
+      "command": "yarn dev:app",
+      "description": "Product app (@hitly/app) on http://localhost:3001"
+    }
+  ],
+  "ports": [
+    { "name": "web", "port": 3000 },
+    { "name": "app", "port": 3001 },
+    { "name": "mariadb", "port": 3306 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Cloud Agent install step for Hitly.
+# Idempotent, non-interactive repository bootstrap. Runs after the source is
+# checked out and (with environment builds) is baked into the base snapshot.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# 1. Docker CLI + compose plugin.
+# The Docker daemon itself is provided by the platform (reachable over
+# tcp://127.0.0.1:2375); we only need the client to talk to it so that
+# `yarn db:up` can bring up the MariaDB service defined in docker-compose.yml.
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  sudo install -m 0755 -d /etc/apt/keyrings
+  if [ ! -f /etc/apt/keyrings/docker.gpg ]; then
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+      | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  fi
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+    | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq docker-ce-cli docker-compose-plugin
+fi
+
+# 2. Workspace dependencies (Yarn 1 + Turbo monorepo).
+yarn install --frozen-lockfile
+
+# 3. App environment file. The real app reads apps/app/.env.local; seed it from
+# the checked-in example and generate a development auth secret if absent.
+if [ ! -f apps/app/.env.local ]; then
+  cp apps/app/.env.example apps/app/.env.local
+  secret="$(openssl rand -hex 16)"
+  sed -i "s|^BETTER_AUTH_SECRET=.*|BETTER_AUTH_SECRET=${secret}|" apps/app/.env.local
+fi

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Cloud Agent start step for Hitly.
+# Runs on every boot: brings up the MariaDB service and applies migrations.
+# Must tolerate restarts and reach a clear success/failure state.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# The platform provides the Docker daemon over TCP; point the client at it.
+export DOCKER_HOST="${DOCKER_HOST:-tcp://127.0.0.1:2375}"
+
+# Wait for the Docker daemon to accept connections.
+for _ in $(seq 1 30); do
+  if docker info >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+# Bring up MariaDB. Compose `--wait` blocks until the healthcheck passes.
+yarn db:up
+
+# Apply Drizzle migrations (idempotent: already-applied migrations are skipped).
+yarn db:migrate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a reproducible Cursor Cloud Agent development environment for the Hitly monorepo so agents boot with dependencies installed, MariaDB running, migrations applied, and both dev servers ready.

New files under `.cursor/`:

- **`environment.json`** — wires `install`, `start`, the `web` (3000) and `app` (3001) dev terminals, and exposes ports 3000/3001/3306.
- **`install.sh`** (idempotent, baked into the base snapshot):
  - Installs the Docker CLI + compose plugin. The Docker daemon is provided by the platform (reachable at `tcp://127.0.0.1:2375`); only the client is needed so `yarn db:up` can bring up the MariaDB service in `docker-compose.yml`.
  - Runs `yarn install --frozen-lockfile` (Yarn 1 + Turbo workspace).
  - Seeds `apps/app/.env.local` from `.env.example` with a generated dev `BETTER_AUTH_SECRET`.
- **`start.sh`** (runs per boot): points the Docker client at the platform daemon, `yarn db:up` (MariaDB, waits for healthcheck), then `yarn db:migrate` (Drizzle, idempotent).

This follows the repo's documented setup (`README.md`, `CONTRIBUTING.md`) and the `hitly-coding` skill (Yarn over npm, MariaDB via `yarn db:up`/`yarn db:migrate`, no Postgres). No app or package code is changed. `apps/app/.env.local` stays git-ignored.

## Verification

Validated end to end on this VM and on a fresh pod via a draft environment build.

Draft build `bld-20260817-91b05682` **SUCCEEDED**: on a clean checkout it installed the Docker CLI + compose plugin, ran `yarn install` (~42s), and seeded the env file — all exit code 0.

On the running environment:

- MariaDB came up healthy; `yarn db:migrate` applied all Drizzle migrations (18 tables created).
- `@hitly/web` serves `http://localhost:3000` (HTTP 200); `@hitly/app` serves `http://localhost:3001`.
- Real DB round-trip: a Better Auth email sign-up persisted a `users` row and created a session; signing in as that user in the browser lands on the authenticated Inbox summary.

Browser walkthrough (marketing site → app login → authenticated inbox):

[hitly_env_web_and_app_login_demo.mp4](https://cursor.com/agents/bc-bc7658c1-03bd-4b1d-bdad-9ae93bc48a5d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhitly_env_web_and_app_login_demo.mp4)

Authenticated app view after login:

[Hitly app authenticated inbox summary](https://cursor.com/agents/bc-bc7658c1-03bd-4b1d-bdad-9ae93bc48a5d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhitly_app_inbox_authenticated.webp)

## Notes

- The draft build was created from this branch to test the committed scripts, so it is validation-only and not promotable. Once merged, `.cursor/environment.json` governs future agents (repo-file managed).
- The environment relies on the platform-provided Docker daemon on `tcp://127.0.0.1:2375`; `start.sh` waits for it before bringing up MariaDB.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc7658c1-03bd-4b1d-bdad-9ae93bc48a5d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc7658c1-03bd-4b1d-bdad-9ae93bc48a5d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

