### PR TITLE
Fix: Display pending invites on Team settings page

### DIFF
--- a/apps/app/actions/team.ts
+++ b/apps/app/actions/team.ts
@@ -66,3 +66,16 @@ export async function removeWorkspaceMember(memberId: string) {
   await database.delete(memberships).where(eq(memberships.id, memberId))
   revalidatePath('/settings/team')
 }
+
+export async function cancelInvite(inviteId: string) {
+  const { workspace, role } = await getAppContext()
+  if (!canManageWorkspace(role)) {
+    throw new Error('Only workspace admins can cancel invites')
+  }
+  const database = requireDb()
+  const rows = await database.select().from(invites).where(eq(invites.id, inviteId)).limit(1)
+  const invite = rows[0]
+  if (!invite || invite.workspaceId !== workspace.id) throw new Error('Invite not found')
+  await database.delete(invites).where(eq(invites.id, inviteId))
+  revalidatePath('/settings/team')
+}

--- a/apps/app/app/settings/team/page.tsx
+++ b/apps/app/app/settings/team/page.tsx
@@ -1,6 +1,6 @@
-import { eq } from 'drizzle-orm'
-import { memberships, users } from '@hitly/db/schema'
-import { inviteToWorkspace, removeWorkspaceMember } from '@/actions/team'
+import { and, eq, gt, isNull } from 'drizzle-orm'
+import { invites, memberships, users } from '@hitly/db/schema'
+import { cancelInvite, inviteToWorkspace, removeWorkspaceMember } from '@/actions/team'
 import { AppShell } from '@/components/app-shell'
 import { getAppContext } from '@/lib/context'
 import { canManageWorkspace } from '@/lib/rbac'
@@ -10,7 +10,8 @@ export const metadata = { title: 'Team' }
 
 export default async function TeamPage() {
   const { workspace, role, user } = await getAppContext()
-  const members = await requireDb()
+  const database = requireDb()
+  const members = await database
     .select({
       id: memberships.id,
       role: memberships.role,
@@ -21,6 +22,23 @@ export default async function TeamPage() {
     .from(memberships)
     .innerJoin(users, eq(memberships.userId, users.id))
     .where(eq(memberships.workspaceId, workspace.id))
+  
+  const pendingInvites = await database
+    .select({
+      id: invites.id,
+      email: invites.email,
+      role: invites.role,
+      expiresAt: invites.expiresAt,
+    })
+    .from(invites)
+    .where(
+      and(
+        eq(invites.workspaceId, workspace.id),
+        isNull(invites.acceptedAt),
+        gt(invites.expiresAt, new Date())
+      )
+    )
+  
   const admin = canManageWorkspace(role)
 
   return (
@@ -71,6 +89,31 @@ export default async function TeamPage() {
           </li>
         ))}
       </ul>
+      {admin && pendingInvites.length > 0 ? (
+        <>
+          <h2 className="mt-8 text-lg font-semibold">Pending invites</h2>
+          <p className="mt-2 text-sm text-zinc-500">
+            These people have been invited but haven&apos;t signed up yet.
+          </p>
+          <ul className="mt-4 max-w-md divide-y divide-zinc-200 dark:divide-zinc-800">
+            {pendingInvites.map((invite) => (
+              <li key={invite.id} className="flex items-center justify-between py-3 text-sm">
+                <div>
+                  <p className="font-medium">{invite.email}</p>
+                  <p className="text-xs text-zinc-500">
+                    {invite.role} · expires {new Date(invite.expiresAt).toLocaleDateString()}
+                  </p>
+                </div>
+                <form action={cancelInvite.bind(null, invite.id)}>
+                  <button type="submit" className="text-xs text-zinc-500 hover:text-red-600">
+                    Cancel
+                  </button>
+                </form>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : null}
     </AppShell>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3

## Problem

The Team settings page (`/settings/team`) only displayed current workspace members, but didn't show pending invites. When inviting an email that doesn't have an account yet, a row is inserted in the `invites` table and email is sent, but the owner never sees these pending invites in the UI.

## Changes

1. **Display pending invites**: The Team page now queries and displays pending (unaccepted, unexpired) invites from the `invites` table
2. **Cancel invites**: Added a `cancelInvite` server action that allows workspace admins to revoke pending invites
3. **UI section**: Added a "Pending invites" section below the members list that shows:
   - Email address
   - Role (member/admin)
   - Expiration date
   - Cancel button (for admins)

## Technical Details

- Modified `apps/app/app/settings/team/page.tsx` to query pending invites using `and(eq(invites.workspaceId, workspace.id), isNull(invites.acceptedAt), gt(invites.expiresAt, new Date()))`
- Added `cancelInvite` server action in `apps/app/actions/team.ts` with proper authorization checks
- Matched existing UI patterns and styling
- Only visible to workspace admins
- Existing functionality preserved: inviting users with existing accounts still adds them as members immediately

## Testing

- ✅ Type checking passes (`yarn typecheck`)
- Existing member list functionality unchanged
- After invited person signs up, they become a member via existing `bootstrapUserWorkspaces` flow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65b57a70-a0f0-49fa-9611-c3227abd3026?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65b57a70-a0f0-49fa-9611-c3227abd3026&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

