### PR TITLE
Use HITLy in marketing and docs copy

### DIFF
--- a/apps/web/components/marketing/feature-blocks.tsx
+++ b/apps/web/components/marketing/feature-blocks.tsx
@@ -1,15 +1,24 @@
 import Link from 'next/link'
+import { HitlyWordmark } from '@hitly/ui'
 
 const features = [
   {
     title: 'Unified review and approval',
     href: '/docs/inbox',
-    body: 'Agents and workflows pause in their own runtime. Reviewers decide in Hitly — same inbox, same decisions, web or mobile. You never approve inside Mastra Studio, Hermes CLI, n8n, or LangGraph.',
+    body: (
+      <>
+        Agents and workflows pause in their own runtime. Reviewers decide in <HitlyWordmark /> — same inbox, same decisions, web or mobile. You never approve inside Mastra Studio, Hermes CLI, n8n, or LangGraph.
+      </>
+    ),
   },
   {
     title: 'Every agent and workflow platform',
     href: '/integrations',
-    body: 'Mastra, Hermes, and HTTP callbacks are available today. n8n Wait is an HTTP recipe. LangGraph and Temporal mappings are documented. Pause primitives stay native; Hitly owns the envelope and the resume.',
+    body: (
+      <>
+        Mastra, Hermes, and HTTP callbacks are available today. n8n Wait is an HTTP recipe. LangGraph and Temporal mappings are documented. Pause primitives stay native; <HitlyWordmark /> owns the envelope and the resume.
+      </>
+    ),
   },
   {
     title: 'Governance and org chart',
@@ -23,7 +32,7 @@ export function FeatureBlocks() {
     <section className="mx-auto max-w-6xl px-6 py-20">
       <h2 className="text-2xl font-semibold">One surface for human decisions</h2>
       <p className="mt-2 max-w-2xl text-zinc-600 dark:text-zinc-400">
-        Hitly is the review layer. Origins keep their pause primitives. Your org keeps the audit trail.
+        <HitlyWordmark /> is the review layer. Origins keep their pause primitives. Your org keeps the audit trail.
       </p>
       <div className="mt-10 grid gap-4 md:grid-cols-3">
         {features.map((feature) => (

--- a/apps/web/components/marketing/how-it-works.tsx
+++ b/apps/web/components/marketing/how-it-works.tsx
@@ -1,15 +1,29 @@
+import { HitlyWordmark } from '@hitly/ui'
+
 const steps = [
   {
     title: 'Pause',
-    body: 'Your workflow hits a Hitly step. Mastra suspends, Hermes prompts or blocks a kanban card, HTTP waits on a resume URL, LangGraph interrupts, Temporal signals.',
+    body: (
+      <>
+        Your workflow hits a <HitlyWordmark /> step. Mastra suspends, Hermes prompts or blocks a kanban card, HTTP waits on a resume URL, LangGraph interrupts, Temporal signals.
+      </>
+    ),
   },
   {
     title: 'Review',
-    body: 'The action lands in the Hitly inbox with context, editable args, and the decisions you allow.',
+    body: (
+      <>
+        The action lands in the <HitlyWordmark /> inbox with context, editable args, and the decisions you allow.
+      </>
+    ),
   },
   {
     title: 'Resume',
-    body: 'Accept, edit, or reject. Hitly maps the decision back to resume(), a webhook, Command, or a Temporal signal.',
+    body: (
+      <>
+        Accept, edit, or reject. <HitlyWordmark /> maps the decision back to resume(), a webhook, Command, or a Temporal signal.
+      </>
+    ),
   },
 ]
 

--- a/apps/web/components/marketing/plugin-grid.tsx
+++ b/apps/web/components/marketing/plugin-grid.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { Badge } from '@hitly/ui'
+import { Badge, HitlyWordmark } from '@hitly/ui'
 
 const plugins = [
   {
@@ -21,28 +21,44 @@ const plugins = [
     name: 'HTTP',
     status: 'Available',
     href: '/integrations/http',
-    body: 'POST ingest with a resumeUrl. Hitly POSTs { decision, id, metadata }. n8n, Notion, Make, custom callbacks.',
+    body: (
+      <>
+        POST ingest with a resumeUrl. <HitlyWordmark /> POSTs {'{ decision, id, metadata }'}. n8n, Notion, Make, custom callbacks.
+      </>
+    ),
   },
   {
     id: 'n8n',
     name: 'n8n',
     status: 'HTTP today',
     href: '/integrations/n8n',
-    body: 'Create an HTTP project. HTTP Request to Hitly, then Wait on webhook. Hitly POSTs to $execution.resumeUrl.',
+    body: (
+      <>
+        Create an HTTP project. HTTP Request to <HitlyWordmark />, then Wait on webhook. <HitlyWordmark /> POSTs to $execution.resumeUrl.
+      </>
+    ),
   },
   {
     id: 'langgraph',
     name: 'LangGraph',
     status: 'Coming soon',
     href: '/integrations/langgraph',
-    body: 'Maps HumanInterrupt onto the Hitly envelope and resumes with HumanResponse.',
+    body: (
+      <>
+        Maps HumanInterrupt onto the <HitlyWordmark /> envelope and resumes with HumanResponse.
+      </>
+    ),
   },
   {
     id: 'temporal',
     name: 'Temporal',
     status: 'Coming soon',
     href: '/integrations/temporal',
-    body: 'Activity creates the approval; condition() waits; Hitly sends hitly.decision.',
+    body: (
+      <>
+        Activity creates the approval; condition() waits; <HitlyWordmark /> sends <code className="text-xs">hitly.decision</code>.
+      </>
+    ),
   },
 ]
 

--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -26,7 +26,7 @@ The key must belong to `HITLY_PROJECT_ID`. Send `Idempotency-Key` when the origi
 
 `mastraBaseUrl` is optional when the project already stores the origin base URL.
 
-HTTP origins send `plugin: "http"`, `resumeUrl`, and optional `metadata`. Hitly echoes `metadata` on the resume POST:
+HTTP origins send `plugin: "http"`, `resumeUrl`, and optional `metadata`. HITL<sub><i>y</i></sub> echoes `metadata` on the resume POST:
 
 ```json
 {
@@ -39,7 +39,7 @@ HTTP origins send `plugin: "http"`, `resumeUrl`, and optional `metadata`. Hitly 
 }
 ```
 
-On accept or reject, Hitly POSTs that `metadata` unchanged to `resumeUrl`:
+On accept or reject, HITL<sub><i>y</i></sub> POSTs that `metadata` unchanged to `resumeUrl`:
 
 ```json
 {

--- a/apps/web/content/docs/envelope.mdx
+++ b/apps/web/content/docs/envelope.mdx
@@ -31,6 +31,6 @@ interface OriginRef {
 
 `resumeHandle` is opaque per plugin (Mastra base URL + run/step ids, Hermes request/task ids, HTTP `resumeUrl` + optional `metadata`, LangGraph thread id, Temporal workflow id). Origin credentials live on the **project**.
 
-HTTP ingest may include `metadata` (a JSON object). It is stored on the envelope and echoed unchanged on the resume POST for both accept and reject, next to `decision` and the Hitly `id`.
+HTTP ingest may include `metadata` (a JSON object). It is stored on the envelope and echoed unchanged on the resume POST for both accept and reject, next to `decision` and the HITL<sub><i>y</i></sub> `id`.
 
 See [Projects](/docs/projects) and the [API](/docs/api).

--- a/apps/web/content/docs/governance.mdx
+++ b/apps/web/content/docs/governance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Governance
-description: Workspace team, project roles, SLA rules, and the audit trail — Hitly's org chart is membership.
+description: Workspace team, project roles, SLA rules, and the audit trail — HITLy's org chart is membership.
 ---
 
 The org is the membership tree: one **workspace**, a **team**, and **projects** that each map to one origin. Roles decide who sees work, who can decide, and who can change config.

--- a/apps/web/content/docs/inbox.mdx
+++ b/apps/web/content/docs/inbox.mdx
@@ -3,7 +3,7 @@ title: Inbox
 description: Pending approvals, decisions, SLA, resume status, and retry.
 ---
 
-The inbox is Hitly's unified review and approval surface. Origins pause with their own primitives — Mastra `suspend()`, Hermes approval transport / `kanban_block`, HTTP `resumeUrl`, LangGraph `interrupt()`, Temporal `condition()` — but they do not decide. Reviewers open one queue for **every visible project and plugin** in the workspace, on web or [mobile](/docs/mobile), and post a `Decision`. The plugin adapter resumes the run.
+The inbox is HITL<sub><i>y</i></sub>'s unified review and approval surface. Origins pause with their own primitives — Mastra `suspend()`, Hermes approval transport / `kanban_block`, HTTP `resumeUrl`, LangGraph `interrupt()`, Temporal `condition()` — but they do not decide. Reviewers open one queue for **every visible project and plugin** in the workspace, on web or [mobile](/docs/mobile), and post a `Decision`. The plugin adapter resumes the run.
 
 Who sees which projects, who can decide, and who only watches is [governance](/docs/governance).
 

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Hitly
+title: HITLy
 description: Pause the agent, review the action, resume the run.
 ---
 
-Hitly is a human-in-the-loop inbox you can self-host (Apache-2.0) or use as a hosted service at [hitly.net](https://hitly.net). Origin frameworks pause; reviewers decide in Hitly; plugins resume the origin run.
+HITL<sub><i>y</i></sub> is a human-in-the-loop inbox you can self-host (Apache-2.0) or use as a hosted service at [hitly.net](https://hitly.net). Origin frameworks pause; reviewers decide in HITL<sub><i>y</i></sub>; plugins resume the origin run.
 
-## What Hitly is
+## What HITL<sub><i>y</i></sub> is
 
 **A unified review and approval surface.** Mastra, Hermes, HTTP callbacks, LangGraph, and Temporal each have their own pause primitive. Reviewers do not approve in those UIs. They open the [inbox](/docs/inbox) — one queue across every visible project, web or mobile — and post a `Decision`. The plugin adapter resumes the origin.
 

--- a/apps/web/content/docs/mobile.mdx
+++ b/apps/web/content/docs/mobile.mdx
@@ -3,15 +3,15 @@ title: Mobile
 description: Reviewer app for iOS and Android — Cloud or hosted login, push, and deep links into a work item.
 ---
 
-The Hitly mobile app is an Expo (React Native) client in `apps/mobile`. It signs into **Hitly Cloud** (`https://cloud.hitly.net`) or a **self-hosted** instance URL, receives device notifications, and opens the approval that needs a decision.
+The HITL<sub><i>y</i></sub> mobile app is an Expo (React Native) client in `apps/mobile`. It signs into **HITL<sub><i>y</i></sub> Cloud** (`https://cloud.hitly.net`) or a **self-hosted** instance URL, receives device notifications, and opens the approval that needs a decision.
 
 Web stays the admin surface for team, rules, people, logs, and API keys. Mobile also has workspace settings, a project list, project inbox, and project config (no key minting).
 
 <PhoneGallery
   shots={[
-    { src: '/images/iPhone-home.png', alt: 'Hitly mobile Home tab with inbox summary counts', caption: 'Home' },
-    { src: '/images/iPhone-inbox.png', alt: 'Hitly mobile Inbox listing send-refund work items', caption: 'Inbox' },
-    { src: '/images/iPhone-projects.png', alt: 'Hitly mobile Projects list for Mastra, HTTP, and LangGraph', caption: 'Projects' },
+    { src: '/images/iPhone-home.png', alt: 'HITLy mobile Home tab with inbox summary counts', caption: 'Home' },
+    { src: '/images/iPhone-inbox.png', alt: 'HITLy mobile Inbox listing send-refund work items', caption: 'Inbox' },
+    { src: '/images/iPhone-projects.png', alt: 'HITLy mobile Projects list for Mastra, HTTP, and LangGraph', caption: 'Projects' },
     { src: '/images/iPhone-send-refund.png', alt: 'send-refund work item with origin, context, data, and decision', caption: 'Work item' },
   ]}
 />
@@ -38,7 +38,7 @@ Assignees with a registered Expo token are pushed on ingest, in addition to emai
 
 ```json
 {
-  "title": "Hitly: send-refund needs a decision",
+  "title": "HITLy: send-refund needs a decision",
   "body": "Acme refunds · expires in 15m",
   "data": { "type": "approval", "approvalId": "apr_…", "instanceUrl": "https://cloud.hitly.net" }
 }

--- a/apps/web/content/docs/self-host.mdx
+++ b/apps/web/content/docs/self-host.mdx
@@ -1,9 +1,9 @@
 ---
 title: Self-host
-description: Run the Apache-2.0 Hitly server yourself.
+description: Run the Apache-2.0 HITLy server yourself.
 ---
 
-This repository is the open-source Hitly server. Self-hosting includes the inbox, projects, plugins, audit log, API keys, and team membership. There are no usage caps.
+This repository is the open-source HITL<sub><i>y</i></sub> server. Self-hosting includes the inbox, projects, plugins, audit log, API keys, and team membership. There are no usage caps.
 
 ## Run locally
 

--- a/apps/web/content/integrations/hermes.mdx
+++ b/apps/web/content/integrations/hermes.mdx
@@ -1,35 +1,35 @@
 ---
 title: Hermes
-description: Route Hermes command approvals and kanban block/review pauses into the Hitly inbox.
+description: Route Hermes command approvals and kanban block/review pauses into the HITLy inbox.
 ---
 
-[Hermes Agent](https://hermes-agent.nousresearch.com) is a Python agent. Hitly does not run inside Hermes — a drop-in plugin POSTs pauses to Hitly, and applies the decision on the Hermes host.
+[Hermes Agent](https://hermes-agent.nousresearch.com) is a Python agent. HITL<sub><i>y</i></sub> does not run inside Hermes — a drop-in plugin POSTs pauses to HITL<sub><i>y</i></sub>, and applies the decision on the Hermes host.
 
 Hermes “personas” are **named profiles** (`~/.hermes/profiles/<name>/`, each with its own `SOUL.md`). Cron is only one unattended runner.
 
-## How it works with Hitly
+## How it works with HITL<sub><i>y</i></sub>
 
 ### Command approval (CLI, gateway, `/background`)
 
 Dangerous terminal / `execute_code` calls pause in Hermes `tools/approval.py`. Selecting `security.approval.transport: hitly` replaces the built-in prompt (including Telegram `/approve`).
 
-1. The plugin `present()` POSTs the command to Hitly and **polls** until you decide.
+1. The plugin `present()` POSTs the command to HITL<sub><i>y</i></sub> and **polls** until you decide.
 2. Accept maps to Hermes `once`; reject / timeout maps to `deny`.
-3. Hermes still enforces `approvals.timeout` (default **300 seconds**). Hitly SLA can be longer; the command still denies when Hermes times out.
+3. Hermes still enforces `approvals.timeout` (default **300 seconds**). HITL<sub><i>y</i></sub> SLA can be longer; the command still denies when Hermes times out.
 
 ### Kanban workers (autonomous profiles)
 
 The gateway dispatcher spawns `hermes -p <profile>` for board tasks. Those workers **exit** when they need a human — they call `kanban_block` or `kanban_request_review`. That is the HITL path for unattended personas.
 
-1. The plugin POSTs a Hitly card (`kind: kanban`).
+1. The plugin POSTs a HITL<sub><i>y</i></sub> card (`kind: kanban`).
 2. Accept → `hermes kanban comment` + `unblock` on the Hermes host (gateway poller).
 3. Reject → comment, leave the card blocked.
 
-Hitly never POSTs into `hermes dashboard` (localhost-only by default).
+HITL<sub><i>y</i></sub> never POSTs into `hermes dashboard` (localhost-only by default).
 
-### What Hitly cannot wait on
+### What HITL<sub><i>y</i></sub> cannot wait on
 
-| Path | Hermes gate | Hitly |
+| Path | Hermes gate | HITLy |
 | --- | --- | --- |
 | Cron jobs | `approvals.cron_mode`: `deny` or `approve` | No wait. Documented only. |
 | Kanban **shell** commands | `approvals.kanban_mode`: `deny` or `approve` | Same. Workers should `kanban_block` instead. |
@@ -37,7 +37,7 @@ Hitly never POSTs into `hermes dashboard` (localhost-only by default).
 
 ## Setup
 
-1. Create a Hitly project with plugin **Hermes** and copy the project API key.
+1. Create a HITL<sub><i>y</i></sub> project with plugin **Hermes** and copy the project API key.
 2. Copy the plugin into Hermes:
 
 ```bash
@@ -68,7 +68,7 @@ Kanban ingest works even if `transport` is unset. Command routing needs both the
 
 ## Decision mapping
 
-| Hitly | Command transport | Kanban |
+| HITLy | Command transport | Kanban |
 | --- | --- | --- |
 | `accept` | Hermes `once` | comment + unblock |
 | `respond` | — | comment (body) + unblock |

--- a/apps/web/content/integrations/http.mdx
+++ b/apps/web/content/integrations/http.mdx
@@ -1,16 +1,16 @@
 ---
 title: HTTP
-description: Pause on a callback URL, review in Hitly, POST the decision JSON.
+description: Pause on a callback URL, review in HITLy, POST the decision JSON.
 ---
 
-Generic HTTP callback. Create a Hitly project with plugin **HTTP**. Any origin that can POST ingest and expose a `resumeUrl` uses this adapter — n8n Wait, Make, Zapier, Notion automations, or a tiny webhook handler.
+Generic HTTP callback. Create a HITL<sub><i>y</i></sub> project with plugin **HTTP**. Any origin that can POST ingest and expose a `resumeUrl` uses this adapter — n8n Wait, Make, Zapier, Notion automations, or a tiny webhook handler.
 
-## How it works with Hitly
+## How it works with HITL<sub><i>y</i></sub>
 
 1. The origin POSTs context + `resumeUrl` to `POST /api/v1/approvals` (`plugin: "http"`).
 2. Whatever owns `resumeUrl` waits (Wait node, scenario, Worker).
-3. Reviewer decides in Hitly.
-4. Hitly POSTs JSON to `resumeUrl`. Ingest `metadata` is echoed unchanged on accept and reject. `id` is the Hitly approval id (unknown at ingest):
+3. Reviewer decides in HITL<sub><i>y</i></sub>.
+4. HITL<sub><i>y</i></sub> POSTs JSON to `resumeUrl`. Ingest `metadata` is echoed unchanged on accept and reject. `id` is the HITL<sub><i>y</i></sub> approval id (unknown at ingest):
 
 ```json
 {
@@ -20,7 +20,7 @@ Generic HTTP callback. Create a Hitly project with plugin **HTTP**. Any origin t
 }
 ```
 
-Put any correlation keys the callback needs in `metadata`. Hitly does not interpret them.
+Put any correlation keys the callback needs in `metadata`. HITL<sub><i>y</i></sub> does not interpret them.
 
 ## Setup
 
@@ -42,11 +42,11 @@ Create an **HTTP** project and copy the API key. Point the origin at ingest:
 
 n8n-shaped fields (`executionId`, `workflowId`, `workflowName`) are optional details. `runId` falls back to `executionId`.
 
-The resume URL must be reachable from Hitly. `localhost` only works when Hitly and the callback run on the same machine.
+The resume URL must be reachable from HITL<sub><i>y</i></sub>. `localhost` only works when HITL<sub><i>y</i></sub> and the callback run on the same machine.
 
 ## Decision mapping
 
-| Hitly | Callback |
+| HITLy | Callback |
 | --- | --- |
 | `accept` | POST `{ "decision": "accept", "id", "metadata" }` |
 | `reject` | POST `{ "decision": "reject", "id", "metadata" }` (branch in the origin) |

--- a/apps/web/content/integrations/index.mdx
+++ b/apps/web/content/integrations/index.mdx
@@ -1,16 +1,16 @@
 ---
 title: Integrations
-description: Wire Mastra, Hermes, HTTP, LangGraph, or Temporal to the Hitly inbox.
+description: Wire Mastra, Hermes, HTTP, LangGraph, or Temporal to the HITLy inbox.
 ---
 
-Hitly supports the agents and workflow platforms you already run. Each origin keeps its native pause primitive. Reviewers still only use Hitly — the [inbox](/docs/inbox) is the same card whether the run came from Mastra, Hermes, an HTTP callback, LangGraph, or Temporal.
+HITL<sub><i>y</i></sub> supports the agents and workflow platforms you already run. Each origin keeps its native pause primitive. Reviewers still only use HITL<sub><i>y</i></sub> — the [inbox](/docs/inbox) is the same card whether the run came from Mastra, Hermes, an HTTP callback, LangGraph, or Temporal.
 
 Add a framework by writing one adapter against the [envelope](/docs/envelope). You do not build a second reviewer UI.
 
 | Plugin | Status | Pause primitive | Resume |
 | --- | --- | --- | --- |
 | [Mastra](/integrations/mastra) | Available | `suspend()` | `run.resume()` / `bail()` |
-| [Hermes](/integrations/hermes) | Available | approval transport / `kanban_block` | origin polls Hitly; kanban comment + unblock |
+| [Hermes](/integrations/hermes) | Available | approval transport / `kanban_block` | origin polls HITL<sub><i>y</i></sub>; kanban comment + unblock |
 | [HTTP](/integrations/http) | Available | caller `resumeUrl` | POST `{ decision, id, metadata }` |
 | [n8n](/integrations/n8n) | HTTP today | Wait webhook | POST to `$execution.resumeUrl` |
 | [LangGraph](/integrations/langgraph) | Coming soon | `interrupt()` | `HumanResponse` |

--- a/apps/web/content/integrations/langgraph.mdx
+++ b/apps/web/content/integrations/langgraph.mdx
@@ -1,24 +1,24 @@
 ---
 title: LangGraph
-description: interrupt(HumanInterrupt) maps onto the Hitly envelope.
+description: interrupt(HumanInterrupt) maps onto the HITLy envelope.
 ---
 
 Status: **coming soon**.
 
-[LangGraph](https://langchain-ai.github.io/langgraph/) pauses with `interrupt()`. Agent Inbox's `HumanInterrupt` is the closest cousin to Hitly's envelope (`accept` / `edit` / `ignore` / `response`).
+[LangGraph](https://langchain-ai.github.io/langgraph/) pauses with `interrupt()`. Agent Inbox's `HumanInterrupt` is the closest cousin to HITL<sub><i>y</i></sub>'s envelope (`accept` / `edit` / `ignore` / `response`).
 
-## How it works with Hitly
+## How it works with HITL<sub><i>y</i></sub>
 
-1. Graph node calls `interrupt(HumanInterrupt)` and notifies Hitly (webhook or callback).
-2. Hitly stores the envelope (`action_request`, `config`, `description`).
+1. Graph node calls `interrupt(HumanInterrupt)` and notifies HITL<sub><i>y</i></sub> (webhook or callback).
+2. HITL<sub><i>y</i></sub> stores the envelope (`action_request`, `config`, `description`).
 3. Reviewer decides.
-4. Hitly resumes the thread with `HumanResponse`.
+4. HITL<sub><i>y</i></sub> resumes the thread with `HumanResponse`.
 
 A checkpointer is required so the graph can pause.
 
 ## Decision mapping
 
-| Hitly | HumanResponse |
+| HITLy | HumanResponse |
 | --- | --- |
 | `accept` | `{ type: 'accept' }` |
 | `edit` | `{ type: 'edit', args: ActionRequest }` |

--- a/apps/web/content/integrations/mastra.mdx
+++ b/apps/web/content/integrations/mastra.mdx
@@ -1,16 +1,16 @@
 ---
 title: Mastra
-description: Suspend a Mastra agent tool or workflow step, review it in Hitly, resume or bail.
+description: Suspend a Mastra agent tool or workflow step, review it in HITLy, resume or bail.
 ---
 
-[Mastra](https://mastra.ai/docs/workflows/human-in-the-loop) pauses with `suspend()` and continues with `resume()` / `bail()`. Hitly owns the reviewer UI. Chat with the demo agent in [Mastra Studio](https://mastra.ai/docs/studio/overview) (`mastra dev`, http://localhost:4111).
+[Mastra](https://mastra.ai/docs/workflows/human-in-the-loop) pauses with `suspend()` and continues with `resume()` / `bail()`. HITL<sub><i>y</i></sub> owns the reviewer UI. Chat with the demo agent in [Mastra Studio](https://mastra.ai/docs/studio/overview) (`mastra dev`, http://localhost:4111).
 
-## How it works with Hitly
+## How it works with HITL<sub><i>y</i></sub>
 
-1. An agent tool or workflow step calls `suspend()` and POSTs the payload to Hitly.
-2. Hitly stores an [envelope](/docs/envelope) and shows it in the [inbox](/docs/inbox).
+1. An agent tool or workflow step calls `suspend()` and POSTs the payload to HITL<sub><i>y</i></sub>.
+2. HITL<sub><i>y</i></sub> stores an [envelope](/docs/envelope) and shows it in the [inbox](/docs/inbox).
 3. A reviewer accepts, edits, or rejects.
-4. Hitly resumes the origin:
+4. HITL<sub><i>y</i></sub> resumes the origin:
    - **Workflow** — `POST /api/workflows/:workflowId/resume`
    - **Agent** — `POST /api/agents/:agentId/resume-stream`
 5. Reject maps to `resumeData.approved: false`. Workflows should `bail()`; agent tools should return a rejection result to the model.
@@ -20,7 +20,7 @@ See the runnable project in `examples/mastra` (agent + workflow).
 <PhoneShot
   src="/images/iPhone-send-refund.png"
   alt="send-refund Mastra work item with refund context, order data, and Accept decision"
-  caption="Refund workflow paused in Hitly"
+  caption="Refund workflow paused in HITLy"
 />
 
 ## Setup
@@ -59,8 +59,8 @@ MASTRA_BASE_URL=http://localhost:4111
 
 1. Scaffold a Mastra project (`yarn create mastra`) or open `examples/mastra`.
 2. In the tool or step `execute`, call `notifyHitlyApproval()`, then `suspend()`.
-3. On resume, call `verifyHitlyResume(resumeData)` then read `resumeData.approved`. If `false`, `bail()` (workflow) or return a rejection (agent tool). Mastra Zod strips unknown keys — `resumeSchema` must `.passthrough()` so the Hitly `hitly` proof survives.
-4. Run `mastra dev` (default `http://localhost:4111`) and Hitly app (`http://localhost:3001`).
+3. On resume, call `verifyHitlyResume(resumeData)` then read `resumeData.approved`. If `false`, `bail()` (workflow) or return a rejection (agent tool). Mastra Zod strips unknown keys — `resumeSchema` must `.passthrough()` so the HITLy `hitly` proof survives.
+4. Run `mastra dev` (default `http://localhost:4111`) and HITL<sub><i>y</i></sub> app (`http://localhost:3001`).
 5. Chat with the agent or start the workflow in Studio. Open `cloud.hitly.net/inbox`, accept, watch the run resume.
 
 ### Workflow step
@@ -105,7 +105,7 @@ const approval = createStep({
 
 ### Agent tool
 
-Do not set `requireApproval: true` if Hitly should see the request. That flag pauses *before* `execute`, so `notifyHitlyApproval` never runs. Suspend inside the tool instead:
+Do not set `requireApproval: true` if HITL<sub><i>y</i></sub> should see the request. That flag pauses *before* `execute`, so `notifyHitlyApproval` never runs. Suspend inside the tool instead:
 
 ```ts
 import { createTool } from '@mastra/core/tools'
@@ -114,7 +114,7 @@ import { notifyHitlyApproval, verifyHitlyResume } from '@hitly/plugin-mastra'
 
 export const sendRefundTool = createTool({
   id: 'send-refund',
-  description: 'Issue a customer refund after Hitly approval.',
+  description: 'Issue a customer refund after HITLy approval.',
   inputSchema: z.object({ orderId: z.string(), amount: z.number() }),
   resumeSchema: z.object({ approved: z.boolean() }).passthrough(),
   suspendSchema: z.object({ reason: z.string() }),
@@ -140,7 +140,7 @@ export const sendRefundTool = createTool({
         { runId: String(runId), suspendPayload: { reason: `Refund ${inputData.amount}` } },
       )
       await context.agent?.suspend?.({ reason: 'Human approval required.' })
-      return { sent: false, message: 'Waiting for Hitly approval.' }
+      return { sent: false, message: 'Waiting for HITLy approval.' }
     }
     return { sent: true, message: 'Refund issued.' }
   },
@@ -149,29 +149,29 @@ export const sendRefundTool = createTool({
 
 ## Running locally
 
-1. `yarn workspace @hitly/app dev` — Hitly on port 3001.
+1. `yarn workspace @hitly/app dev` — HITL<sub><i>y</i></sub> on port 3001.
 2. `yarn workspace @hitly/example-mastra dev` (or `yarn dev:mastra`) — Studio on 4111.
 3. Chat with **Refund Agent** or run **refund-workflow**. Approve in the inbox.
 
 ## Production
 
-Hitly must reach `mastraBaseUrl` to call `resume()`. Do not point a hosted Hitly workspace at `localhost`. Restrict Mastra CORS and use a token with workflow/agent resume access.
+HITL<sub><i>y</i></sub> must reach `mastraBaseUrl` to call `resume()`. Do not point a hosted HITL<sub><i>y</i></sub> workspace at `localhost`. Restrict Mastra CORS and use a token with workflow/agent resume access.
 
 ## Configuration options
 
 | Option | Use it to |
 | --- | --- |
-| `apiUrl` | Hitly app origin, such as `https://cloud.hitly.net` |
+| `apiUrl` | HITL<sub><i>y</i></sub> app origin, such as `https://cloud.hitly.net` |
 | `apiKey` | Workspace ingest key |
 | `projectId` | Project that owns the API key |
-| `mastraBaseUrl` | Origin Mastra server Hitly will call on resume |
+| `mastraBaseUrl` | Origin Mastra server HITL<sub><i>y</i></sub> will call on resume |
 | `kind` | `workflow` (default) or `agent` |
 | `workflowId` / `stepId` | Workflow resume target |
 | `agentId` / `toolCallId` | Agent resume target |
 
 ## Decision mapping
 
-| Hitly | Mastra |
+| HITLy | Mastra |
 | --- | --- |
 | `accept` | `resume({ resumeData: { approved: true } })` |
 | `edit` | `resume({ resumeData: { approved: true, ...editedArgs } })` |

--- a/apps/web/content/integrations/n8n.mdx
+++ b/apps/web/content/integrations/n8n.mdx
@@ -1,18 +1,18 @@
 ---
 title: n8n
-description: Pause on a Wait webhook, review in Hitly, POST the resume URL.
+description: Pause on a Wait webhook, review in HITLy, POST the resume URL.
 ---
 
 The [HTTP](/integrations/http) adapter is available today — create an **HTTP** project and hand-roll a Wait node.
 
 [n8n](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.wait/) pauses with a Wait node. Resume happens only via `$execution.resumeUrl` (or form URL).
 
-## How it works with Hitly
+## How it works with HITL<sub><i>y</i></sub>
 
-1. Notion Trigger (or HTTP Request) POSTs context + `$execution.resumeUrl` to Hitly ingest with `plugin: "http"`.
+1. Notion Trigger (or HTTP Request) POSTs context + `$execution.resumeUrl` to HITL<sub><i>y</i></sub> ingest with `plugin: "http"`.
 2. Wait node **On Webhook Call** on the **same chain** (not a second Webhook trigger).
-3. Reviewer decides in Hitly.
-4. Hitly POSTs `{ decision, id, metadata }` to `$execution.resumeUrl` and the Wait node continues.
+3. Reviewer decides in HITL<sub><i>y</i></sub>.
+4. HITL<sub><i>y</i></sub> POSTs `{ decision, id, metadata }` to `$execution.resumeUrl` and the Wait node continues.
 
 A disconnected Webhook node on the same canvas is a separate workflow. Its `/webhook-test/...` URL 404s unless you click Listen; production `/webhook/...` only works when that Webhook is the trigger of an **active** workflow.
 
@@ -25,18 +25,18 @@ A disconnected Webhook node on the same canvas is a separate workflow. Its `/web
 <DocShot
   src="/images/notion-content-database.png"
   alt="Notion Content database with Software licences In review"
-  caption="Notion Status In review creates the Hitly item"
+  caption="Notion Status In review creates the HITLy item"
 />
 
 <DocShot
   src="/images/hitly-notion-approval.png"
-  alt="Hitly work item for notion-approval with Software licences context and Accept or Reject"
-  caption="Reviewer decides in Hitly; Wait then PATCHes Notion"
+  alt="HITLy work item for notion-approval with Software licences context and Accept or Reject"
+  caption="Reviewer decides in HITLy; Wait then PATCHes Notion"
 />
 
 ## Setup (hand-roll today)
 
-Create a Hitly project with plugin **HTTP**. Point an HTTP Request node at `POST /api/v1/approvals` with a project API key, `plugin: "http"`, `projectId`, `resumeUrl` (`$execution.resumeUrl`), and any `metadata` you need echoed on decide.
+Create a HITL<sub><i>y</i></sub> project with plugin **HTTP**. Point an HTTP Request node at `POST /api/v1/approvals` with a project API key, `plugin: "http"`, `projectId`, `resumeUrl` (`$execution.resumeUrl`), and any `metadata` you need echoed on decide.
 
 Set `WEBHOOK_URL` on self-hosted n8n so resume URLs are not `localhost`.
 
@@ -44,7 +44,7 @@ Step-by-step recipe: [`examples/n8n`](https://github.com/hitly-net/hitly/blob/ma
 
 ## Decision mapping
 
-| Hitly | n8n |
+| HITLy | n8n |
 | --- | --- |
 | `accept` | POST `{ "decision": "accept", "id", "metadata" }` |
 | `reject` | POST `{ "decision": "reject", "id", "metadata" }` (branch in the workflow) |

--- a/apps/web/content/integrations/temporal.mdx
+++ b/apps/web/content/integrations/temporal.mdx
@@ -5,14 +5,14 @@ description: Wait on condition(), resume with signal hitly.decision.
 
 Status: **coming soon**.
 
-[Temporal](https://docs.temporal.io/design-patterns/approval) pauses with `condition()` until a Signal (or times out). Hitly does not hold a worker; it signals the workflow.
+[Temporal](https://docs.temporal.io/design-patterns/approval) pauses with `condition()` until a Signal (or times out). HITL<sub><i>y</i></sub> does not hold a worker; it signals the workflow.
 
-## How it works with Hitly
+## How it works with HITL<sub><i>y</i></sub>
 
-1. An activity POSTs an approval to Hitly.
+1. An activity POSTs an approval to HITL<sub><i>y</i></sub>.
 2. The workflow `await condition(() => decision !== undefined, timeout)`.
 3. Reviewer decides.
-4. Hitly sends signal `hitly.decision` with `{ decision, args }`.
+4. HITL<sub><i>y</i></sub> sends signal `hitly.decision` with `{ decision, args }`.
 
 ## Configuration
 

--- a/apps/web/lib/llms.ts
+++ b/apps/web/lib/llms.ts
@@ -35,17 +35,17 @@ export function buildLlmsIndex(): string {
 
   return toAbsoluteMarkdown(
     [
-      '# Hitly',
+      '# HITLy',
       '',
-      '> Hitly is the review inbox for agents and workflows. Origins (Mastra, Hermes, HTTP, LangGraph, Temporal) keep pause/resume; reviewers decide in Hitly. Cloud is waitlist-only; self-host is available now.',
+      '> HITLy is the review inbox for agents and workflows. Origins (Mastra, Hermes, HTTP, LangGraph, Temporal) keep pause/resume; reviewers decide in HITLy. Cloud is waitlist-only; self-host is available now.',
       '',
       ...sections,
       '',
       '## Also',
       '',
       '- [GitHub](https://github.com/hitly-net/hitly): Apache-2.0 source, examples, and plugins',
-      '- [AGENT.md](https://github.com/hitly-net/hitly/blob/main/AGENT.md): drop-in recipe for coding agents implementing Hitly in an existing project',
-      '- [Cloud waitlist](https://hitly.net/#waitlist): hosted Hitly is not generally available yet',
+      '- [AGENT.md](https://github.com/hitly-net/hitly/blob/main/AGENT.md): drop-in recipe for coding agents implementing HITLy in an existing project',
+      '- [Cloud waitlist](https://hitly.net/#waitlist): hosted HITLy is not generally available yet',
       '',
     ].join('\n'),
   )

--- a/apps/web/lib/source.ts
+++ b/apps/web/lib/source.ts
@@ -50,7 +50,7 @@ export const integrationsSource = loader({
 /** One sidebar: Docs and Integrations as nested folders, used by both layouts. */
 export function getNavTree(): PageTree.Root {
   return {
-    name: 'Hitly',
+    name: 'HITLy',
     children: [...source.getPageTree().children, ...integrationsSource.getPageTree().children],
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Site-wide rebrand of the product name in user-facing copy from "Hitly" to "HITLy" (with preferred HTML wordmark HITL<sub><i>y</i></sub>).

## Changes

### Marketing Components
- **how-it-works.tsx**: Use `<HitlyWordmark />` component in Pause/Review/Resume steps
- **feature-blocks.tsx**: Use `<HitlyWordmark />` in feature descriptions
- **plugin-grid.tsx**: Use `<HitlyWordmark />` in plugin descriptions; use `<code>` for `hitly.decision` identifier

### Documentation (MDX)
- **Docs**: index, self-host, inbox, api, envelope, governance, mobile
- **Integrations**: mastra, http, hermes, n8n, langgraph, temporal, index
- Use `HITL<sub><i>y</i></sub>` HTML in body copy
- Use plain `HITLy` in YAML frontmatter titles and descriptions
- Update alt text, captions, table headers, push notification titles

### Library Files
- **source.ts**: Sidebar name "Hitly" → "HITLy"
- **llms.ts**: Product name in llms.txt index and descriptions

## Not Changed

Code identifiers, package names, environment variables, wire formats, and URLs remain unchanged:
- Function names: `createHitlyApprovalStep`, `notifyHitlyApproval`, `verifyHitlyResume`, `HitlyWordmark`, `HitlyIcon`
- Packages: `@hitly/*`
- Env vars: `HITLY_*`
- Wire formats: `hitly.decision`, `hitly_...` API keys
- URLs: hitly.net, cloud.hitly.net
- Import paths, CSS classes, file names

## Testing

Manually verified grep shows no remaining user-visible "Hitly" in marketing/docs/integrations copy.

```bash
rg -n '\bHitly\b' apps/web/components/marketing apps/web/content apps/web/app
# No matches
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4ad7f60-380e-4c02-974b-6e21bc27e994?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4ad7f60-380e-4c02-974b-6e21bc27e994&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

