### PR TITLE
Add ™ to marketing header and footer

### DIFF
--- a/apps/web/components/marketing/site-chrome.tsx
+++ b/apps/web/components/marketing/site-chrome.tsx
@@ -11,7 +11,7 @@ export function SiteHeader() {
     <header className="border-b border-zinc-200 bg-white/80 backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/80 md:sticky md:top-0 md:z-50">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
         <Link href="/" className="inline-flex">
-          <HitlyWordmark className="text-lg" />
+          <HitlyWordmark className="text-lg" trademark />
         </Link>
         <nav className="flex items-center gap-6 text-sm">
           {links.map((link) => (
@@ -36,7 +36,7 @@ export function SiteFooter() {
     <footer className="mt-auto border-t border-zinc-200 py-10 dark:border-zinc-800">
       <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 text-sm text-zinc-500">
         <p>
-          <HitlyWordmark /> — approval inbox for agent work.
+          <HitlyWordmark trademark /> — approval inbox for agent work.
         </p>
         <div className="flex gap-4">
           <Link href="/docs">Docs</Link>

--- a/packages/ui/src/hitly-brand.tsx
+++ b/packages/ui/src/hitly-brand.tsx
@@ -4,11 +4,12 @@ import { cn } from './cn'
 const SANS = 'var(--font-sans), ui-sans-serif, system-ui, sans-serif'
 const SERIF = 'ui-serif, Georgia, "Times New Roman", serif'
 
-export function HitlyWordmark({ className }: { className?: string }) {
+export function HitlyWordmark({ className, trademark }: { className?: string; trademark?: boolean }) {
   return (
-    <span className={cn('font-semibold tracking-tight', className)} aria-label="HITLy">
+    <span className={cn('font-semibold tracking-tight', className)} aria-label={trademark ? 'HITLy™' : 'HITLy'}>
       <span aria-hidden="true">
         HITL<sub className="italic text-[0.65em] leading-none">y</sub>
+        {trademark && <span>™</span>}
       </span>
     </span>
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the ™ trademark symbol to the HITLy wordmark on the public marketing site, appearing only in the header and footer.

## Changes
- Added optional `trademark` prop to `HitlyWordmark` component in `@hitly/ui`
- When `trademark={true}`, appends ™ after the subscript y
- Passed `trademark` prop in `SiteHeader` and `SiteFooter` only
- Footer now reads: **HITLy™ — approval inbox for agent work**

## What's unchanged
- Other `HitlyWordmark` usages (docs, feature blocks, plugin grid, how-it-works, etc.) remain without ™
- No changes to app chrome, sidebar, login, mobile, or favicons
- Narrow change focused only on marketing header and footer

## Testing
- ✅ Typecheck passed
- ✅ Lint passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16b8366d-3e01-4630-8ab0-d24a3f07907c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16b8366d-3e01-4630-8ab0-d24a3f07907c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

