### PR TITLE
Add Metaspan Ltd legal line to marketing footer

### DIFF
--- a/apps/web/components/marketing/site-chrome.tsx
+++ b/apps/web/components/marketing/site-chrome.tsx
@@ -35,9 +35,23 @@ export function SiteFooter() {
   return (
     <footer className="mt-auto border-t border-zinc-200 py-10 dark:border-zinc-800">
       <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 text-sm text-zinc-500">
-        <p>
-          <HitlyWordmark trademark /> — approval inbox for agent work.
-        </p>
+        <div className="flex flex-col gap-1">
+          <p>
+            <HitlyWordmark trademark /> — approval inbox for agent work.
+          </p>
+          <p className="text-xs text-zinc-500">
+            <HitlyWordmark /> is a product of Metaspan Ltd (company no.{' '}
+            <a
+              href="https://find-and-update.company-information.service.gov.uk/company/13641200"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-zinc-900 dark:hover:text-zinc-50"
+            >
+              13641200
+            </a>
+            ).
+          </p>
+        </div>
         <div className="flex gap-4">
           <Link href="/docs">Docs</Link>
           <Link href="/privacy">Privacy</Link>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a small legal footer line to the HITLy public marketing site.

## Changes
- Added legal line under the existing tagline in `SiteFooter`: "HITLy is a product of Metaspan Ltd (company no. 13641200)."
- Uses `HitlyWordmark` component without trademark for the product name
- Links only the company number (13641200) to Companies House with `target="_blank"` and `rel="noopener noreferrer"`
- Styled as small legal text (`text-xs text-zinc-500`) stacked under the tagline on the left side

## Scope
- Marketing footer only (`apps/web/components/marketing/site-chrome.tsx`)
- Does not affect app chrome, docs, or other areas
- No metaspan.com link included (as requested)

## Verification
- ✅ Lint passed
- ✅ Typecheck passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed95b2c5-1c68-4839-9aca-aae15568ab2a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed95b2c5-1c68-4839-9aca-aae15568ab2a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

