### PR TITLE
Remove leftover conflict markers from envelope.mdx

### DIFF
--- a/apps/web/content/docs/envelope.mdx
+++ b/apps/web/content/docs/envelope.mdx
@@ -75,11 +75,7 @@ Evidence fields provide audit context for compliance and governance. All are opt
 | `sensitivity` | Implementor | Sensitivity flags (not raw PII) |
 | `dataCategories` | Implementor | Data category flags for GDPR/compliance |
 
-<<<<<<< HEAD
-**HITLy is deployer tooling, not the high-risk system.** `systemId` refers to *your* system (the one being governed), not HITLy itself.
-=======
-**Hitly is deployer tooling, not the high-risk system.** `systemId` is the AI system you are governing (e.g. your agent or workflow deployment). `inventoryId` is that system's entry in your AI inventory/registry, not a business resource like an order ID or user ID.
->>>>>>> 11dc1de (feat: add test button, fix inventoryId docs, update mastra examples)
+**HITLy is deployer tooling, not the high-risk system.** `systemId` is the AI system you are governing (e.g. your agent or workflow deployment). `inventoryId` is that system's entry in your AI inventory/registry, not a business resource like an order ID or user ID.
 
 ### What Mastra Fills Automatically
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes git conflict markers that were accidentally committed to `apps/web/content/docs/envelope.mdx`.

## Changes

- Replaced conflict block in envelope.mdx with the correct merged paragraph
- Keeps HITLy branding and inventoryId meaning from the evidence PR
- No other conflict markers found in the repository

## Context

Production build was failing due to leftover conflict markers in the MDX file. This hotfix resolves the parsing issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d7bf4e-0e52-4f85-8c9f-c6a02ed05cac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d7bf4e-0e52-4f85-8c9f-c6a02ed05cac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

