### PR TITLE
Use H-slash favicon (idle / open-approvals)

### DIFF
--- a/apps/app/app/icon-open.svg
+++ b/apps/app/app/icon-open.svg
@@ -4,4 +4,6 @@
   <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
   <!-- Slash (the y) from (318,418) to (428,318) -->
   <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
+  <!-- Red dot for open approvals -->
+  <circle cx="388" cy="368" r="46" fill="#ef4444"/>
 </svg>

--- a/apps/app/app/icon.svg
+++ b/apps/app/app/icon.svg
@@ -1,4 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
-  <rect width="800" height="800" fill="#18181b"/>
-  <text x="400" y="475" text-anchor="middle" fill="#fafafa" style="font-family: ui-sans-serif, system-ui, sans-serif; font-size: 280px; font-weight: 700; letter-spacing: -8px;">HITL<tspan baseline-shift="sub" style="font-size: 0.62em; font-style: italic; letter-spacing: 0;">y</tspan></text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#18181b"/>
+  <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
+  <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
+  <!-- Slash (the y) from (318,418) to (428,318) -->
+  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
 </svg>

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Geist, Geist_Mono } from 'next/font/google'
 import type { ReactNode } from 'react'
 import './globals.css'
+import { FaviconUpdater } from '@/components/favicon-updater'
 
 const geist = Geist({ subsets: ['latin'], variable: '--font-sans' })
 const geistMono = Geist_Mono({ subsets: ['latin'], variable: '--font-mono' })
@@ -14,6 +15,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
       <body className="h-dvh overflow-hidden bg-zinc-50 font-sans text-zinc-950 antialiased dark:bg-zinc-950 dark:text-zinc-50">
+        <FaviconUpdater />
         {children}
       </body>
     </html>

--- a/apps/app/components/favicon-updater.tsx
+++ b/apps/app/components/favicon-updater.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function FaviconUpdater() {
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout
+
+    async function updateFavicon() {
+      try {
+        const response = await fetch('/api/v1/inbox/summary')
+        if (!response.ok) return
+        
+        const summary = await response.json() as {
+          pending: number
+          failedResume: number
+          decidedToday: number
+          projectCount: number
+        }
+
+        const hasOpenItems = (summary.pending + summary.failedResume) > 0
+        const iconPath = hasOpenItems ? '/icon-open.svg' : '/icon.svg'
+
+        const link = document.querySelector<HTMLLinkElement>("link[rel*='icon']") 
+          || document.createElement('link')
+        link.type = 'image/svg+xml'
+        link.rel = 'icon'
+        link.href = iconPath
+
+        if (!link.parentNode) {
+          document.head.appendChild(link)
+        }
+      } catch {
+        // TODO: Wire to real-time inbox updates when available
+        // Silently fail for now - keep existing favicon
+      }
+    }
+
+    function scheduleUpdate() {
+      updateFavicon()
+      timeoutId = setTimeout(scheduleUpdate, 30000) // Poll every 30s
+    }
+
+    scheduleUpdate()
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [])
+
+  return null
+}

--- a/apps/web/app/apple-icon.svg
+++ b/apps/web/app/apple-icon.svg
@@ -1,4 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
-  <rect width="800" height="800" fill="#18181b"/>
-  <text x="400" y="475" text-anchor="middle" fill="#fafafa" style="font-family: ui-sans-serif, system-ui, sans-serif; font-size: 280px; font-weight: 700; letter-spacing: -8px;">HITL<tspan baseline-shift="sub" style="font-size: 0.62em; font-style: italic; letter-spacing: 0;">y</tspan></text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#18181b"/>
+  <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
+  <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
+  <!-- Slash (the y) from (318,418) to (428,318) -->
+  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
 </svg>

--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -1,4 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
-  <rect width="800" height="800" fill="#18181b"/>
-  <text x="400" y="475" text-anchor="middle" fill="#fafafa" style="font-family: ui-sans-serif, system-ui, sans-serif; font-size: 280px; font-weight: 700; letter-spacing: -8px;">HITL<tspan baseline-shift="sub" style="font-size: 0.62em; font-style: italic; letter-spacing: 0;">y</tspan></text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#18181b"/>
+  <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
+  <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
+  <!-- Slash (the y) from (318,418) to (428,318) -->
+  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
 </svg>

--- a/packages/ui/src/hitly-brand.tsx
+++ b/packages/ui/src/hitly-brand.tsx
@@ -2,7 +2,6 @@ import type { SVGProps } from 'react'
 import { cn } from './cn'
 
 const SANS = 'var(--font-sans), ui-sans-serif, system-ui, sans-serif'
-const SERIF = 'ui-serif, Georgia, "Times New Roman", serif'
 
 export function HitlyWordmark({ className, trademark }: { className?: string; trademark?: boolean }) {
   return (
@@ -15,30 +14,20 @@ export function HitlyWordmark({ className, trademark }: { className?: string; tr
   )
 }
 
-/** HITLy wordmark icon (square tile, suitable for avatars/favicons). */
+/** HITLy H-slash mark (square tile, suitable for avatars/favicons). */
 export function HitlyIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 800 800"
+      viewBox="0 0 512 512"
       role="img"
       aria-label="HITLy"
       className={cn('h-8 w-8 shrink-0', className)}
       {...props}
     >
-      <rect width="800" height="800" fill="#18181b" />
-      <text
-        x="400"
-        y="475"
-        textAnchor="middle"
-        fill="#fafafa"
-        style={{ fontFamily: SANS, fontSize: 280, fontWeight: 700, letterSpacing: '-8px' }}
-      >
-        HITL
-        <tspan baselineShift="sub" style={{ fontSize: '0.62em', fontStyle: 'italic', letterSpacing: 0 }}>
-          y
-        </tspan>
-      </text>
+      <rect width="512" height="512" fill="#18181b" />
+      <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
+      <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" strokeWidth="48" strokeLinecap="round"/>
     </svg>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the full HITLy wordmark favicon with the locked H-slash design.

## Changes

### Favicon files
- **Marketing** (`apps/web`): Idle H+slash only (no red dot badge)
  - `app/icon.svg` and `app/apple-icon.svg`
- **App** (`apps/app`): Dynamic favicon swap based on pending approvals
  - `app/icon.svg` and `app/apple-icon.svg` (idle state)
  - `app/icon-open.svg` (open-approvals state with red dot)

### Client logic
- Added `FaviconUpdater` component that polls `/api/v1/inbox/summary` every 30s
- Swaps to red-dot favicon when `pending + failedResume > 0`
- Integrated into root layout for the app

### UI package
- Updated `HitlyIcon` component (`packages/ui`) to use H-slash design
- Suitable for small square mark/favicon-like usage
- No trademark symbol

## Design specs (512px canvas)
- **H glyph**: Geist Bold-inspired, 400px tall, centered with -8px offset
- **Slash** (the y): White line from (318,418) to (428,318), 48px stroke, round cap
- **Red dot** (open-approvals): Circle at cx=388 cy=368 r=46, fill #ef4444

## Notes
- Marketing site keeps idle favicon only (no badge)
- App favicon updates dynamically based on inbox state
- Uses SVG paths instead of font glyphs for crisp rendering at small sizes
- Typecheck passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dd21991-946f-4482-9e1b-1a3c2da953ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dd21991-946f-4482-9e1b-1a3c2da953ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

