### PR TITLE
Add first-party Plausible snippet on marketing

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import { RootProvider } from 'fumadocs-ui/provider/next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import Script from 'next/script'
 import type { ReactNode } from 'react'
 import './globals.css'
 
@@ -25,6 +26,11 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col font-sans">
+        <Script
+          src="https://click.hitly.net/js/script.js"
+          data-domain="hitly.net"
+          strategy="afterInteractive"
+        />
         <RootProvider>{children}</RootProvider>
       </body>
     </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the first-party Plausible analytics snippet to the marketing site (`apps/web`) using Next.js Script component.

The snippet points to `https://click.hitly.net/js/script.js` with domain `hitly.net` and is only added to the marketing site layout, not the inbox app.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-159171f9-5e17-411d-a03f-58b3dd1f9960?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159171f9-5e17-411d-a03f-58b3dd1f9960&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

