### PR TITLE
Use H-check favicon (idle blue / open red)

### DIFF
--- a/apps/app/app/apple-icon.svg
+++ b/apps/app/app/apple-icon.svg
@@ -2,6 +2,6 @@
   <rect width="512" height="512" fill="#18181b"/>
   <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
   <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
-  <!-- Slash (the y) from (318,418) to (428,318) -->
-  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
+  <!-- Check mark (idle blue) -->
+  <path d="M318 372 L362 416 L448 308" stroke="#2563eb" stroke-width="52" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/apps/app/app/icon-open.svg
+++ b/apps/app/app/icon-open.svg
@@ -2,8 +2,6 @@
   <rect width="512" height="512" fill="#18181b"/>
   <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
   <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
-  <!-- Slash (the y) from (318,418) to (428,318) -->
-  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
-  <!-- Red dot for open approvals -->
-  <circle cx="388" cy="368" r="46" fill="#ef4444"/>
+  <!-- Check mark (open red) -->
+  <path d="M318 372 L362 416 L448 308" stroke="#ef4444" stroke-width="52" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/apps/app/app/icon.svg
+++ b/apps/app/app/icon.svg
@@ -2,6 +2,6 @@
   <rect width="512" height="512" fill="#18181b"/>
   <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
   <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
-  <!-- Slash (the y) from (318,418) to (428,318) -->
-  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
+  <!-- Check mark (idle blue) -->
+  <path d="M318 372 L362 416 L448 308" stroke="#2563eb" stroke-width="52" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/apps/web/app/apple-icon.svg
+++ b/apps/web/app/apple-icon.svg
@@ -2,6 +2,6 @@
   <rect width="512" height="512" fill="#18181b"/>
   <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
   <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
-  <!-- Slash (the y) from (318,418) to (428,318) -->
-  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
+  <!-- Check mark (idle blue) -->
+  <path d="M318 372 L362 416 L448 308" stroke="#2563eb" stroke-width="52" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -2,6 +2,6 @@
   <rect width="512" height="512" fill="#18181b"/>
   <!-- H glyph (Geist Bold inspired, 400px, centered at 248,256) -->
   <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
-  <!-- Slash (the y) from (318,418) to (428,318) -->
-  <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" stroke-width="48" stroke-linecap="round"/>
+  <!-- Check mark (idle blue) -->
+  <path d="M318 372 L362 416 L448 308" stroke="#2563eb" stroke-width="52" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
 </svg>

--- a/packages/ui/src/hitly-brand.tsx
+++ b/packages/ui/src/hitly-brand.tsx
@@ -14,7 +14,7 @@ export function HitlyWordmark({ className, trademark }: { className?: string; tr
   )
 }
 
-/** HITLy H-slash mark (square tile, suitable for avatars/favicons). */
+/** HITLy H-check mark (square tile, suitable for avatars/favicons). */
 export function HitlyIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (
     <svg
@@ -27,7 +27,7 @@ export function HitlyIcon({ className, ...props }: SVGProps<SVGSVGElement>) {
     >
       <rect width="512" height="512" fill="#18181b" />
       <path d="M88,56 L168,56 L168,216 L328,216 L328,56 L408,56 L408,456 L328,456 L328,296 L168,296 L168,456 L88,456 Z" fill="#fafafa"/>
-      <line x1="318" y1="418" x2="428" y2="318" stroke="#fafafa" strokeWidth="48" strokeLinecap="round"/>
+      <path d="M318 372 L362 416 L448 308" stroke="#2563eb" strokeWidth="52" strokeLinecap="round" strokeLinejoin="round" fill="none"/>
     </svg>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the H+slash favicon from #13 with the H+checkmark design per Derek's preference.

## Changes

- **Idle state**: Blue checkmark (#2563eb) for normal/marketing use
- **Open state**: Red checkmark (#ef4444) when approvals are pending
- Removed the red notification dot (check color now signals state)
- Updated `HitlyIcon` component comment

## Files Updated

- `packages/ui/src/hitly-brand.tsx` — HitlyIcon component
- `apps/web/app/icon.svg` + `apple-icon.svg` — Marketing site (idle blue only)
- `apps/app/app/icon.svg` + `apple-icon.svg` — App (idle blue)
- `apps/app/app/icon-open.svg` — App open state (red check)

## Checkmark Geometry

```
Path: M318 372 L362 416 L448 308
stroke-width: 52
stroke-linecap: round
stroke-linejoin: round
```

## Favicon Swap

`FaviconUpdater` continues to work as before:
- `/icon-open.svg` when `pending + failedResume > 0`
- `/icon.svg` otherwise
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7fabeb4-5c44-44ab-accf-292dd06a5725?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7fabeb4-5c44-44ab-accf-292dd06a5725&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

