### PR TITLE
Use HitlyWordmark in Evidence Storage copy

### DIFF
--- a/apps/app/app/projects/[id]/config/page.tsx
+++ b/apps/app/app/projects/[id]/config/page.tsx
@@ -1,6 +1,7 @@
 import { and, eq } from 'drizzle-orm'
 import { redirect } from 'next/navigation'
 import { projectApiKeys, projectMemberships, users } from '@hitly/db/schema'
+import { HitlyWordmark } from '@hitly/ui'
 import { updateProjectConfig } from '@/actions/projects'
 import { AppShell } from '@/components/app-shell'
 import { ProjectApiKeys } from '@/components/project-api-keys'
@@ -117,7 +118,7 @@ export default async function ProjectConfigPage({ params }: { params: Promise<{ 
 
         <h3 className="mt-4 text-sm font-semibold">Evidence Storage</h3>
         <p className="text-xs text-zinc-500">
-          Evidence is written to your URL. Hitly keeps a receipt only. Decide will not resume the origin if this URL fails.
+          Evidence is written to your URL. <HitlyWordmark className="text-xs font-normal" /> keeps a receipt only. Decide will not resume the origin if this URL fails.
         </p>
         <select
           name="evidenceSinkType"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #17

Replace plain text "Hitly" with the `HitlyWordmark` component from `@hitly/ui` in the Evidence Storage section of the project config page.

The component renders "HITL" with an italic subscript "y" and is imported the same way other app chrome uses it. Applied inline styling (`text-xs font-normal`) to match the surrounding paragraph text, avoiding the default header/semibold look.

**Changes:**
- Import `HitlyWordmark` from `@hitly/ui`
- Replace plain text "Hitly" with `<HitlyWordmark className="text-xs font-normal" />`

The wordmark now appears inline in the helper text: "Evidence is written to your URL. HITLy keeps a receipt only. Decide will not resume the origin if this URL fails."
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acd95bb1-b716-4a6b-9198-cdd8a3303c10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acd95bb1-b716-4a6b-9198-cdd8a3303c10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

