### PR TITLE
Optional evidence sink headers and metadata

### DIFF
--- a/apps/app/actions/projects.ts
+++ b/apps/app/actions/projects.ts
@@ -114,6 +114,8 @@ export async function updateProjectConfig(projectId: string, formData: FormData)
       evidenceSinkType: formData.get('evidenceSinkType'),
       evidenceSinkUrl: formData.get('evidenceSinkUrl'),
       evidenceSinkAuthHeader: formData.get('evidenceSinkAuthHeader'),
+      evidenceSinkHeaders: formData.get('evidenceSinkHeaders'),
+      evidenceSinkMetadata: formData.get('evidenceSinkMetadata'),
     })
     if ('error' in parsed) throw new Error(parsed.error)
     const result = await saveProjectConfig(projectId, parsed)

--- a/apps/app/app/projects/[id]/config/page.tsx
+++ b/apps/app/app/projects/[id]/config/page.tsx
@@ -140,6 +140,24 @@ export default async function ProjectConfigPage({ params }: { params: Promise<{ 
           placeholder="Authorization header (leave blank to keep)"
           className="h-10 rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
         />
+        <textarea
+          name="evidenceSinkHeaders"
+          defaultValue=""
+          placeholder="Custom headers (one per line: Name: value)"
+          className="min-h-20 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        />
+        <p className="text-xs text-zinc-500">
+          Optional custom HTTP headers sent with each evidence POST. One per line like <code>X-Store-Token: abc123</code>. Transport-only, not stored in the evidence event.
+        </p>
+        <textarea
+          name="evidenceSinkMetadata"
+          defaultValue=""
+          placeholder='Metadata JSON object: {"tenant":"acme","bucket":"audit"}'
+          className="min-h-20 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        />
+        <p className="text-xs text-zinc-500">
+          Optional metadata JSON object sent as <code>X-Hitly-Metadata</code> header with each evidence POST. Transport-only, not stored in the evidence event.
+        </p>
 
         <button
           type="submit"

--- a/apps/app/lib/evidence-sink.test.ts
+++ b/apps/app/lib/evidence-sink.test.ts
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { HttpEvidenceSink } from './evidence-sink'
+import type { EvidenceEvent } from '@hitly/core'
+
+test('HttpEvidenceSink sends custom headers', async () => {
+  const mockEvent: EvidenceEvent = {
+    spec: 'hitly.evidence.v1',
+    event_id: 'evt_123',
+    approval_id: 'apr_456',
+    event_type: 'requested',
+    seq: 1,
+    occurred_at: '2024-01-01T00:00:00.000Z',
+    origin: {
+      plugin: 'mastra',
+      projectId: 'prj_789',
+      runId: 'run_abc',
+    },
+    action: {
+      name: 'test',
+      args: {},
+      proposed_sha256: 'abc123',
+    },
+    retention: {
+      min_days: 180,
+    },
+    integrity: {
+      alg: 'sha256',
+      content_sha256: 'test_hash',
+    },
+  }
+
+  let capturedHeaders: Record<string, string> = {}
+  let capturedBody = ''
+
+  global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+    if (init?.headers) {
+      capturedHeaders = init.headers as Record<string, string>
+    }
+    if (init?.body) {
+      capturedBody = init.body as string
+    }
+    return new Response(JSON.stringify({
+      event_id: mockEvent.event_id,
+      content_sha256: mockEvent.integrity.content_sha256,
+      store_uri: 'https://example.com/evt_123',
+      stored_at: '2024-01-01T00:00:00.000Z',
+    }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  const sink = new HttpEvidenceSink({
+    url: 'https://example.com/evidence',
+    headers: {
+      'X-Custom-Header': 'custom-value',
+      'X-Store-Token': 'secret123',
+    },
+  })
+
+  await sink.append(mockEvent)
+
+  assert.equal(capturedHeaders['content-type'], 'application/json')
+  assert.equal(capturedHeaders['idempotency-key'], 'evt_123')
+  assert.equal(capturedHeaders['X-Custom-Header'], 'custom-value')
+  assert.equal(capturedHeaders['X-Store-Token'], 'secret123')
+})
+
+test('HttpEvidenceSink sends X-Hitly-Metadata header when metadata is provided', async () => {
+  const mockEvent: EvidenceEvent = {
+    spec: 'hitly.evidence.v1',
+    event_id: 'evt_123',
+    approval_id: 'apr_456',
+    event_type: 'requested',
+    seq: 1,
+    occurred_at: '2024-01-01T00:00:00.000Z',
+    origin: {
+      plugin: 'mastra',
+      projectId: 'prj_789',
+      runId: 'run_abc',
+    },
+    action: {
+      name: 'test',
+      args: {},
+      proposed_sha256: 'abc123',
+    },
+    retention: {
+      min_days: 180,
+    },
+    integrity: {
+      alg: 'sha256',
+      content_sha256: 'test_hash',
+    },
+  }
+
+  let capturedHeaders: Record<string, string> = {}
+
+  global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+    if (init?.headers) {
+      capturedHeaders = init.headers as Record<string, string>
+    }
+    return new Response(JSON.stringify({
+      event_id: mockEvent.event_id,
+      content_sha256: mockEvent.integrity.content_sha256,
+      store_uri: 'https://example.com/evt_123',
+      stored_at: '2024-01-01T00:00:00.000Z',
+    }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  const sink = new HttpEvidenceSink({
+    url: 'https://example.com/evidence',
+    metadata: {
+      tenant: 'acme',
+      bucket: 'audit',
+    },
+  })
+
+  await sink.append(mockEvent)
+
+  assert.equal(capturedHeaders['X-Hitly-Metadata'], JSON.stringify({ tenant: 'acme', bucket: 'audit' }))
+})
+
+test('HttpEvidenceSink does not merge metadata into event body', async () => {
+  const mockEvent: EvidenceEvent = {
+    spec: 'hitly.evidence.v1',
+    event_id: 'evt_123',
+    approval_id: 'apr_456',
+    event_type: 'requested',
+    seq: 1,
+    occurred_at: '2024-01-01T00:00:00.000Z',
+    origin: {
+      plugin: 'mastra',
+      projectId: 'prj_789',
+      runId: 'run_abc',
+    },
+    action: {
+      name: 'test',
+      args: {},
+      proposed_sha256: 'abc123',
+    },
+    retention: {
+      min_days: 180,
+    },
+    integrity: {
+      alg: 'sha256',
+      content_sha256: 'test_hash',
+    },
+  }
+
+  let capturedBody = ''
+
+  global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+    if (init?.body) {
+      capturedBody = init.body as string
+    }
+    return new Response(JSON.stringify({
+      event_id: mockEvent.event_id,
+      content_sha256: mockEvent.integrity.content_sha256,
+      store_uri: 'https://example.com/evt_123',
+      stored_at: '2024-01-01T00:00:00.000Z',
+    }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  const sink = new HttpEvidenceSink({
+    url: 'https://example.com/evidence',
+    metadata: {
+      tenant: 'acme',
+      bucket: 'audit',
+    },
+  })
+
+  await sink.append(mockEvent)
+
+  const sentEvent = JSON.parse(capturedBody)
+  assert.equal(sentEvent.tenant, undefined)
+  assert.equal(sentEvent.bucket, undefined)
+  assert.equal(sentEvent.metadata, undefined)
+  assert.equal(sentEvent.event_id, 'evt_123')
+  assert.equal(sentEvent.integrity.content_sha256, 'test_hash')
+})
+
+test('HttpEvidenceSink does not override content-type and idempotency-key', async () => {
+  const mockEvent: EvidenceEvent = {
+    spec: 'hitly.evidence.v1',
+    event_id: 'evt_123',
+    approval_id: 'apr_456',
+    event_type: 'requested',
+    seq: 1,
+    occurred_at: '2024-01-01T00:00:00.000Z',
+    origin: {
+      plugin: 'mastra',
+      projectId: 'prj_789',
+      runId: 'run_abc',
+    },
+    action: {
+      name: 'test',
+      args: {},
+      proposed_sha256: 'abc123',
+    },
+    retention: {
+      min_days: 180,
+    },
+    integrity: {
+      alg: 'sha256',
+      content_sha256: 'test_hash',
+    },
+  }
+
+  let capturedHeaders: Record<string, string> = {}
+
+  global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+    if (init?.headers) {
+      capturedHeaders = init.headers as Record<string, string>
+    }
+    return new Response(JSON.stringify({
+      event_id: mockEvent.event_id,
+      content_sha256: mockEvent.integrity.content_sha256,
+      store_uri: 'https://example.com/evt_123',
+      stored_at: '2024-01-01T00:00:00.000Z',
+    }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  const sink = new HttpEvidenceSink({
+    url: 'https://example.com/evidence',
+    headers: {
+      'content-type': 'text/plain',
+      'idempotency-key': 'should-be-ignored',
+    },
+  })
+
+  await sink.append(mockEvent)
+
+  assert.equal(capturedHeaders['content-type'], 'application/json')
+  assert.equal(capturedHeaders['idempotency-key'], 'evt_123')
+})
+
+test('HttpEvidenceSink authHeader overrides custom authorization header', async () => {
+  const mockEvent: EvidenceEvent = {
+    spec: 'hitly.evidence.v1',
+    event_id: 'evt_123',
+    approval_id: 'apr_456',
+    event_type: 'requested',
+    seq: 1,
+    occurred_at: '2024-01-01T00:00:00.000Z',
+    origin: {
+      plugin: 'mastra',
+      projectId: 'prj_789',
+      runId: 'run_abc',
+    },
+    action: {
+      name: 'test',
+      args: {},
+      proposed_sha256: 'abc123',
+    },
+    retention: {
+      min_days: 180,
+    },
+    integrity: {
+      alg: 'sha256',
+      content_sha256: 'test_hash',
+    },
+  }
+
+  let capturedHeaders: Record<string, string> = {}
+
+  global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+    if (init?.headers) {
+      capturedHeaders = init.headers as Record<string, string>
+    }
+    return new Response(JSON.stringify({
+      event_id: mockEvent.event_id,
+      content_sha256: mockEvent.integrity.content_sha256,
+      store_uri: 'https://example.com/evt_123',
+      stored_at: '2024-01-01T00:00:00.000Z',
+    }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  const sink = new HttpEvidenceSink({
+    url: 'https://example.com/evidence',
+    authHeader: 'Bearer correct-token',
+    headers: {
+      authorization: 'Bearer wrong-token',
+    },
+  })
+
+  await sink.append(mockEvent)
+
+  assert.equal(capturedHeaders.authorization, 'Bearer correct-token')
+})
+
+test('HttpEvidenceSink skips empty metadata object', async () => {
+  const mockEvent: EvidenceEvent = {
+    spec: 'hitly.evidence.v1',
+    event_id: 'evt_123',
+    approval_id: 'apr_456',
+    event_type: 'requested',
+    seq: 1,
+    occurred_at: '2024-01-01T00:00:00.000Z',
+    origin: {
+      plugin: 'mastra',
+      projectId: 'prj_789',
+      runId: 'run_abc',
+    },
+    action: {
+      name: 'test',
+      args: {},
+      proposed_sha256: 'abc123',
+    },
+    retention: {
+      min_days: 180,
+    },
+    integrity: {
+      alg: 'sha256',
+      content_sha256: 'test_hash',
+    },
+  }
+
+  let capturedHeaders: Record<string, string> = {}
+
+  global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+    if (init?.headers) {
+      capturedHeaders = init.headers as Record<string, string>
+    }
+    return new Response(JSON.stringify({
+      event_id: mockEvent.event_id,
+      content_sha256: mockEvent.integrity.content_sha256,
+      store_uri: 'https://example.com/evt_123',
+      stored_at: '2024-01-01T00:00:00.000Z',
+    }), { status: 200, headers: { 'content-type': 'application/json' } })
+  }
+
+  const sink = new HttpEvidenceSink({
+    url: 'https://example.com/evidence',
+    metadata: {},
+  })
+
+  await sink.append(mockEvent)
+
+  assert.equal(capturedHeaders['X-Hitly-Metadata'], undefined)
+})

--- a/apps/app/lib/evidence-sink.ts
+++ b/apps/app/lib/evidence-sink.ts
@@ -3,6 +3,8 @@ import type { AppendReceipt, EvidenceEvent, EvidenceSink } from '@hitly/core'
 export interface HttpSinkConfig {
   url: string
   authHeader?: string
+  headers?: Record<string, string>
+  metadata?: Record<string, unknown>
 }
 
 export class HttpEvidenceSink implements EvidenceSink {
@@ -19,8 +21,20 @@ export class HttpEvidenceSink implements EvidenceSink {
       'idempotency-key': event.event_id,
     }
 
+    if (this.config.headers) {
+      for (const [name, value] of Object.entries(this.config.headers)) {
+        if (name && name !== 'content-type' && name !== 'idempotency-key') {
+          headers[name] = value
+        }
+      }
+    }
+
     if (this.config.authHeader) {
       headers.authorization = this.config.authHeader
+    }
+
+    if (this.config.metadata && Object.keys(this.config.metadata).length > 0) {
+      headers['X-Hitly-Metadata'] = JSON.stringify(this.config.metadata)
     }
 
     const response = await fetch(this.config.url, {
@@ -80,9 +94,20 @@ export class NoneSink implements EvidenceSink {
   }
 }
 
-export function createEvidenceSink(config: { type: 'none' | 'http'; url?: string; authHeader?: string }): EvidenceSink {
+export function createEvidenceSink(config: {
+  type: 'none' | 'http'
+  url?: string
+  authHeader?: string
+  headers?: Record<string, string>
+  metadata?: Record<string, unknown>
+}): EvidenceSink {
   if (config.type === 'http' && config.url) {
-    return new HttpEvidenceSink({ url: config.url, authHeader: config.authHeader })
+    return new HttpEvidenceSink({
+      url: config.url,
+      authHeader: config.authHeader,
+      headers: config.headers,
+      metadata: config.metadata,
+    })
   }
   return new NoneSink()
 }

--- a/apps/app/lib/evidence.ts
+++ b/apps/app/lib/evidence.ts
@@ -243,10 +243,23 @@ async function loadProjectSinkConfig(projectId: string, workspaceId: string) {
   const config = row.evidenceSinkConfig
     ? await decodeTenantJson(workspaceId, row.evidenceSinkConfig as Record<string, unknown>)
     : {}
+
+  const headers =
+    config.headers && typeof config.headers === 'object' && !Array.isArray(config.headers)
+      ? (config.headers as Record<string, string>)
+      : undefined
+
+  const metadata =
+    config.metadata && typeof config.metadata === 'object' && !Array.isArray(config.metadata)
+      ? (config.metadata as Record<string, unknown>)
+      : undefined
+
   return {
     type: row.evidenceSinkType as 'none' | 'http',
     url: optionalString(config.url),
     authHeader: optionalString(config.authHeader),
+    headers,
+    metadata,
   }
 }
 

--- a/apps/app/lib/project-config.ts
+++ b/apps/app/lib/project-config.ts
@@ -17,6 +17,8 @@ export type ProjectConfigInput = {
   evidenceSinkType: 'none' | 'http'
   evidenceSinkUrl: string
   evidenceSinkAuthHeader: string
+  evidenceSinkHeaders: string
+  evidenceSinkMetadata: string
 }
 
 export function parseProjectConfig(input: Record<string, unknown>): ProjectConfigInput | { error: string } {
@@ -33,6 +35,20 @@ export function parseProjectConfig(input: Record<string, unknown>): ProjectConfi
   const evidenceSinkType = typeof input.evidenceSinkType === 'string' ? input.evidenceSinkType.trim() : 'none'
   const evidenceSinkUrl = typeof input.evidenceSinkUrl === 'string' ? input.evidenceSinkUrl.trim() : ''
   const evidenceSinkAuthHeader = typeof input.evidenceSinkAuthHeader === 'string' ? input.evidenceSinkAuthHeader.trim() : ''
+  const evidenceSinkHeaders = typeof input.evidenceSinkHeaders === 'string' ? input.evidenceSinkHeaders.trim() : ''
+  const evidenceSinkMetadata = typeof input.evidenceSinkMetadata === 'string' ? input.evidenceSinkMetadata.trim() : ''
+
+  if (evidenceSinkMetadata) {
+    try {
+      const parsed = JSON.parse(evidenceSinkMetadata)
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return { error: 'Metadata must be a JSON object' }
+      }
+    } catch {
+      return { error: 'Metadata must be valid JSON' }
+    }
+  }
+
   return {
     name,
     description,
@@ -46,6 +62,8 @@ export function parseProjectConfig(input: Record<string, unknown>): ProjectConfi
     evidenceSinkType: evidenceSinkType === 'http' ? 'http' : 'none',
     evidenceSinkUrl,
     evidenceSinkAuthHeader,
+    evidenceSinkHeaders,
+    evidenceSinkMetadata,
   }
 }
 
@@ -81,9 +99,32 @@ export async function saveProjectConfig(projectId: string, input: ProjectConfigI
     credentials.resumeSecret = generateResumeSecret()
   }
 
-  const sinkConfig: Record<string, unknown> = {}
+  let sinkConfig: Record<string, unknown> = {}
+  if (project.evidenceSinkConfig) {
+    const existing = await decodeTenantJson(workspaceId, project.evidenceSinkConfig)
+    sinkConfig = existing as Record<string, unknown>
+  }
+
   if (input.evidenceSinkUrl) sinkConfig.url = input.evidenceSinkUrl
   if (input.evidenceSinkAuthHeader) sinkConfig.authHeader = input.evidenceSinkAuthHeader
+  if (input.evidenceSinkHeaders) {
+    const headers: Record<string, string> = {}
+    for (const line of input.evidenceSinkHeaders.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed) {
+        const colonIndex = trimmed.indexOf(':')
+        if (colonIndex > 0) {
+          const name = trimmed.slice(0, colonIndex).trim()
+          const value = trimmed.slice(colonIndex + 1).trim()
+          if (name) headers[name] = value
+        }
+      }
+    }
+    sinkConfig.headers = headers
+  }
+  if (input.evidenceSinkMetadata) {
+    sinkConfig.metadata = JSON.parse(input.evidenceSinkMetadata)
+  }
 
   await database
     .update(projects)

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -11,7 +11,7 @@
     "start": "next start --port 3001",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test lib/approvals.spine.test.ts"
+    "test": "tsx --test lib/approvals.spine.test.ts lib/evidence-sink.test.ts"
   },
   "dependencies": {
     "@hitly/mail": "*",

--- a/apps/web/content/docs/envelope.mdx
+++ b/apps/web/content/docs/envelope.mdx
@@ -117,11 +117,18 @@ Configure an HTTP evidence sink in project settings:
 1. **Sink Type**: `None` (default) or `HTTP`
 2. **Sink URL**: POST destination for evidence events
 3. **Authorization Header**: Optional auth token
+4. **Custom Headers**: Optional HTTP headers (one per line: `Name: value`)
+5. **Metadata**: Optional JSON object sent as transport-only metadata
 
 Evidence events are POSTed to your URL with:
 - `Content-Type: application/json`
 - `Idempotency-Key: <event_id>`
+- `Authorization` header (if configured)
+- Custom HTTP headers (if configured)
+- `X-Hitly-Metadata` header with JSON-encoded metadata (if configured)
 - Full event JSON body (see `packages/core/src/evidence.ts`)
+
+**Important**: Custom headers and metadata are **transport-only**. They are sent with the HTTP request but are **not stored in the evidence event body**. This preserves the `content_sha256` hash. Use them to pass routing information, credentials, or context to your storage backend without affecting the canonical evidence record.
 
 HITLy stores a **receipt index only**, not the payload as system of record. Evidence lifecycle:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview
Adds optional pass-through custom headers and metadata to HITLy project Evidence Storage config. Any HTTP sink can use them to pass routing information, credentials, or context without affecting the canonical evidence record.

## Changes

### Core Implementation
- Added `headers` (Record<string, string>) and `metadata` (Record<string, unknown>) fields to `HttpSinkConfig`
- Updated `HttpEvidenceSink.append()` to:
  - Send custom headers from `headers` config (skips `content-type` and `idempotency-key`)
  - Send metadata as `X-Hitly-Metadata` header with JSON.stringify when non-empty
  - Maintain existing behavior: `authHeader` takes precedence over custom `authorization` header
  - Keep event body unchanged (metadata and custom headers are transport-only)

### Config Management
- Updated `parseProjectConfig` to accept and validate `evidenceSinkHeaders` and `evidenceSinkMetadata`
  - Headers: one per line format (`Name: value`)
  - Metadata: must be valid JSON object (returns error if invalid)
- Updated `saveProjectConfig` to:
  - Parse headers from line-based format into Record<string, string>
  - Parse and store metadata as JSON object
  - Preserve existing values when fields are blank (same pattern as authHeader)
- Updated `loadProjectSinkConfig` to load and pass through headers and metadata

### UI
- Added two optional textarea fields in project config:
  - **Custom headers**: one per line (`X-Store-Token: abc123`)
  - **Metadata**: JSON object (`{"tenant":"acme","bucket":"audit"}`)
- Added explanatory text: these are sent with each POST but not stored in the evidence event

### Tests
- Added `apps/app/lib/evidence-sink.test.ts` with 6 tests:
  - Custom headers are sent correctly
  - X-Hitly-Metadata header is sent when metadata is provided
  - Metadata is NOT merged into event body (preserves content_sha256)
  - content-type and idempotency-key cannot be overridden
  - authHeader overrides custom authorization header
  - Empty metadata object is skipped
- Updated `apps/app/package.json` test script to include new test file
- All tests pass ✓

### Documentation
- Updated `apps/web/content/docs/envelope.mdx` Evidence Storage section:
  - Documents custom headers and metadata fields
  - Emphasizes transport-only nature (not stored in event body, preserves content_sha256)
  - Lists all headers sent with evidence POST

## Design Decisions

1. **Transport-only**: Headers and metadata are sent only with the HTTP request, never merged into the evidence event body. This preserves the `content_sha256` hash.

2. **Header precedence**: 
   - `content-type` and `idempotency-key` cannot be overridden
   - `authHeader` takes precedence over custom `authorization` header (dedicated secret field wins)

3. **Metadata encoding**: Sent as single `X-Hitly-Metadata` header with JSON.stringify. Receivers that don't care can ignore it.

4. **Validation**: Invalid metadata JSON returns clear error on save (not 500).

5. **UI pattern**: Follows same "leave blank to keep" pattern as Authorization field for secret-like values.

## Testing
- ✅ Unit tests pass (6/6)
- ✅ Typechecks pass
- ✅ No changes to existing evidence event structure
- ✅ Custom headers and metadata are optional (backward compatible)

## Related
Follows HITLy coding conventions. No Playwright, no WORM/Art 26, no vendor lock-in (generic HTTP sink feature).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b8d919e-d40e-4000-8d79-3c8adf1f2635?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b8d919e-d40e-4000-8d79-3c8adf1f2635&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

