### PR TITLE
Fix LangGraph demo Command import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ CLAUDE.md
 __pycache__/
 *.py[cod]
 *$py.class
+*.egg-info/
 .venv/
 venv/
 ENV/

--- a/examples/langgraph/src/server.py
+++ b/examples/langgraph/src/server.py
@@ -16,6 +16,7 @@ import uvicorn
 import os
 from dotenv import load_dotenv
 
+from langgraph.types import Command
 from .refund_graph import refund_graph, RefundState
 
 load_dotenv()

--- a/examples/langgraph/src/test_refund_graph.py
+++ b/examples/langgraph/src/test_refund_graph.py
@@ -10,6 +10,13 @@ from src.hitly import notify_hitly_approval, HitlyApprovalConfig
 from src.resume_auth import verify_hitly_resume, HitlyResumeError
 
 
+def test_server_imports_command():
+    """Test that server.py properly imports Command (regression test)."""
+    import src.server
+    # Command should be available in server module namespace
+    assert hasattr(src.server, 'Command'), "server.py must import Command from langgraph.types"
+
+
 @pytest.mark.asyncio
 async def test_notify_hitly_payload():
     """Test that notify_hitly sends the correct payload shape."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes a `NameError` in `examples/langgraph/src/server.py` where `Command` is used but never imported.

## Changes

- Added `from langgraph.types import Command` to `server.py` 
- Added regression test `test_server_imports_command()` to verify Command is properly imported
- Added `*.egg-info/` to root `.gitignore` to prevent pip artifacts from being committed

## Issue

The `resume_thread` endpoint (line 111) calls `Command(resume=resume_value)` but the import was missing, which would cause a `NameError` at runtime when the endpoint is called.

## Testing

The new test verifies that `Command` is available in the `server` module namespace, preventing this regression in the future.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f2cf475-a125-4f19-9c3b-58271eeef277?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f2cf475-a125-4f19-9c3b-58271eeef277&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

