### PR TITLE
Mark LangGraph available on marketing

### DIFF
--- a/apps/web/components/marketing/feature-blocks.tsx
+++ b/apps/web/components/marketing/feature-blocks.tsx
@@ -16,7 +16,7 @@ const features = [
     href: '/integrations',
     body: (
       <>
-        Mastra, Hermes, and HTTP callbacks are available today. n8n Wait is an HTTP recipe. LangGraph and Temporal mappings are documented. Pause primitives stay native; <HitlyWordmark /> owns the envelope and the resume.
+        Mastra, Hermes, HTTP, and LangGraph are available today. n8n Wait is an HTTP recipe. Temporal is documented. Pause primitives stay native; <HitlyWordmark /> owns the envelope and the resume.
       </>
     ),
   },

--- a/apps/web/components/marketing/plugin-grid.tsx
+++ b/apps/web/components/marketing/plugin-grid.tsx
@@ -41,11 +41,11 @@ const plugins = [
   {
     id: 'langgraph',
     name: 'LangGraph',
-    status: 'Coming soon',
+    status: 'Available',
     href: '/integrations/langgraph',
     body: (
       <>
-        Maps HumanInterrupt onto the <HitlyWordmark /> envelope and resumes with HumanResponse.
+        notify_hitly_approval() then interrupt(). Signed HumanResponse resumes the original thread. First-class plugin.
       </>
     ),
   },

--- a/apps/web/content/integrations/index.mdx
+++ b/apps/web/content/integrations/index.mdx
@@ -13,5 +13,5 @@ Add a framework by writing one adapter against the [envelope](/docs/envelope). Y
 | [Hermes](/integrations/hermes) | Available | approval transport / `kanban_block` | origin polls HITL<sub><i>y</i></sub>; kanban comment + unblock |
 | [HTTP](/integrations/http) | Available | caller `resumeUrl` | POST `{ decision, id, metadata }` |
 | [n8n](/integrations/n8n) | HTTP today | Wait webhook | POST to `$execution.resumeUrl` |
-| [LangGraph](/integrations/langgraph) | Coming soon | `interrupt()` | `HumanResponse` |
+| [LangGraph](/integrations/langgraph) | Available | `interrupt()` | `Command({ resume: HumanResponse })` |
 | [Temporal](/integrations/temporal) | Coming soon | `condition()` | signal `hitly.decision` |

--- a/apps/web/content/integrations/langgraph.mdx
+++ b/apps/web/content/integrations/langgraph.mdx
@@ -17,7 +17,7 @@ description: Pause LangGraph agents for human approval before sensitive actions.
    - `ignore` (HITL<sub><i>y</i></sub> reject) → bail without taking the action
    - `edit` → apply edited arguments, then proceed
 
-**Competitive note**: Agent Inbox / hitl.sh collect an answer; HITL<sub><i>y</i></sub> pauses the agent, takes a decision, resumes the original run with proof.
+Agent Inbox / hitl.sh collect an answer; HITL<sub><i>y</i></sub> pauses the agent, takes a decision, resumes the original run with proof. Origins keep interrupt(); HITL<sub><i>y</i></sub> owns the envelope and the signed resume.
 
 See the runnable project in `examples/langgraph` (refund graph with FastAPI server).
 
@@ -165,8 +165,14 @@ async def resume_thread(thread_id: str, req: ResumeRequest):
 
 1. `yarn workspace @hitly/app dev` — HITL<sub><i>y</i></sub> on port 3001.
 2. `cd examples/langgraph && python -m src.server` — FastAPI server on port 2024.
-3. `curl -X POST http://127.0.0.1:2024/refund -d '{"order_id": "OR-1234", "amount": 123.45}'`
-4. Approve or reject in the inbox at http://localhost:3001/inbox.
+3. Open http://127.0.0.1:2024 in your browser to see the demo page.
+4. Click "Request Refund" to start the graph. When it pauses, decide in the HITL<sub><i>y</i></sub> inbox at http://localhost:3001/inbox.
+
+Alternatively, start threads via API:
+
+```bash
+curl -X POST http://127.0.0.1:2024/refund -H 'Content-Type: application/json' -d '{"order_id": "OR-1234", "amount": 123.45}'
+```
 
 ## Production
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates marketing content to reflect that LangGraph shipped (PR #27, hotfix #28).

## Changes

### 1. Homepage plugin card (`apps/web/components/marketing/plugin-grid.tsx`)
- Changed LangGraph status from "Coming soon" to "Available" (same badge as Mastra)
- Updated body text: "notify_hitly_approval() then interrupt(). Signed HumanResponse resumes the original thread. First-class plugin."

### 2. Homepage feature block (`apps/web/components/marketing/feature-blocks.tsx`)
- Updated availability statement from "Mastra, Hermes, and HTTP callbacks are available today. n8n Wait is an HTTP recipe. LangGraph and Temporal mappings are documented." to "Mastra, Hermes, HTTP, and LangGraph are available today. n8n Wait is an HTTP recipe. Temporal is documented."

### 3. Integrations index (`apps/web/content/integrations/index.mdx`)
- Changed LangGraph row to: Available | `interrupt()` | `Command({ resume: HumanResponse })`

### 4. LangGraph integration page (`apps/web/content/integrations/langgraph.mdx`)
- Updated competitive note to full sentence (removed "Competitive note:" label)
- Fixed "Running locally" section to lead with demo page flow (matching examples/langgraph/README.md):
  - Step 3: Open http://127.0.0.1:2024 in browser
  - Step 4: Click "Request Refund" and decide in inbox
  - Curl POST is now listed as an alternative

## Out of scope
- Temporal (still coming soon)
- Mastra pages
- Other integrations

**Do not merge** — for review only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82a9d7e5-b5d8-4653-a7c7-3a35478749f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82a9d7e5-b5d8-4653-a7c7-3a35478749f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

