### PR TITLE
Fix Mastra partner path: monorepo clone, not npm or Cloud

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -23,7 +23,7 @@ Do not resume the run yourself after the POST. Hitly does that.
 
 Confirm all of this exists. If it does not, stop and tell the user what to create.
 
-1. A running Hitly app (self-host `yarn dev:app` on http://localhost:3001, or Cloud at https://cloud.hitly.net).
+1. A running Hitly app (self-host `yarn dev:app` on http://localhost:3001; `cloud.hitly.net` is waitlist-only).
 2. A **project** whose plugin matches the origin (`mastra`, `hermes`, `http`, `langgraph`, `temporal`).
 3. A project API key and `HITLY_PROJECT_ID` (Config tab → Origin `.env`).
 4. Origin **base URL** stored on the project (or sent as `mastraBaseUrl` / equivalent on ingest). Hitly must be able to reach that URL to resume. `localhost` only works when Hitly and the origin run on the same machine.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Apache-2.0 human-in-the-loop inbox for Mastra, Hermes, HTTP, n8n. LangGraph and 
 Self-host this repo, or use the hosted product at [hitly.net](https://hitly.net). Cloud-only features (Stripe billing, usage metering, SSO) live in a private overlay package — they are not env-var flags in this tree.
 
 - `hitly.net` — marketing + docs (`apps/web`, port 3000)
-- `cloud.hitly.net` — hosted product (`apps/app`, port 3001)
+- `http://localhost:3001` — self-hosted inbox (`apps/app`, `yarn dev:app`)
 - iOS / Android reviewer — Expo app (`apps/mobile`, `yarn dev:mobile`)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Apache-2.0 human-in-the-loop inbox for Mastra, Hermes, HTTP, n8n. LangGraph and Temporal coming soon.
 
-Self-host this repo, or use the hosted product at [hitly.net](https://hitly.net). Cloud-only features (Stripe billing, usage metering, SSO) live in a private overlay package — they are not env-var flags in this tree.
+Self-host this repo. Cloud-only features (Stripe billing, usage metering, SSO) live in a private overlay package — they are not env-var flags in this tree. `cloud.hitly.net` is reserved for a hosted offering (waitlist-only); join the waitlist at [hitly.net](https://hitly.net).
 
 - `hitly.net` — marketing + docs (`apps/web`, port 3000)
-- `cloud.hitly.net` — hosted product (`apps/app`, port 3001)
+- `http://localhost:3001` — self-hosted inbox (`apps/app`, `yarn dev:app`)
 - iOS / Android reviewer — Expo app (`apps/mobile`, `yarn dev:mobile`)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Apache-2.0 human-in-the-loop inbox for Mastra, Hermes, HTTP, n8n. LangGraph and 
 Self-host this repo, or use the hosted product at [hitly.net](https://hitly.net). Cloud-only features (Stripe billing, usage metering, SSO) live in a private overlay package — they are not env-var flags in this tree.
 
 - `hitly.net` — marketing + docs (`apps/web`, port 3000)
-- `http://localhost:3001` — self-hosted inbox (`apps/app`, `yarn dev:app`)
+- `cloud.hitly.net` — hosted product (`apps/app`, port 3001)
 - iOS / Android reviewer — Expo app (`apps/mobile`, `yarn dev:mobile`)
 
 ```bash

--- a/apps/web/components/marketing/plugin-grid.tsx
+++ b/apps/web/components/marketing/plugin-grid.tsx
@@ -7,7 +7,7 @@ const plugins = [
     name: 'Mastra',
     status: 'Available',
     href: '/integrations/mastra',
-    body: 'createHitlyApprovalStep() wraps suspend() and resume(). First-class plugin.',
+    body: 'notifyHitlyApproval() wraps suspend() and resume(). First-class plugin.',
   },
   {
     id: 'hermes',

--- a/apps/web/content/docs/envelope.mdx
+++ b/apps/web/content/docs/envelope.mdx
@@ -84,28 +84,32 @@ The Mastra plugin automatically captures:
 - `agentId` (for agent approvals)
 - `runId`, `stepId`, `toolCallId` (always)
 
-Everything else must be passed by the implementor via `createHitlyApprovalStep()` config.
+Everything else must be passed by the implementor via `notifyHitlyApproval()` config.
 
 ### Example: Mastra with Evidence
 
 ```ts
-import { createHitlyApprovalStep } from '@hitly/plugin-mastra'
+import { notifyHitlyApproval } from '@hitly/plugin-mastra'
 
-const approvalStep = createHitlyApprovalStep({
-  apiUrl: process.env.HITLY_API_URL,
-  apiKey: process.env.HITLY_API_KEY,
-  projectId: process.env.HITLY_PROJECT_ID,
-  agentId: 'refund-agent',
-  action: { name: 'send_refund', args: { orderId, amount } },
+await notifyHitlyApproval(
+  {
+    apiUrl: process.env.HITLY_API_URL!,
+    apiKey: process.env.HITLY_API_KEY!,
+    projectId: process.env.HITLY_PROJECT_ID!,
+    mastraBaseUrl: process.env.MASTRA_BASE_URL!,
+    agentId: 'refund-agent',
+    action: { name: 'send_refund', args: { orderId, amount } },
 
-  // Evidence fields the implementor must provide
-  systemId: 'refund-agent-prod',
-  inventoryId: 'ai-inv-refund-agent-v2',  // Your AI inventory record, not orderId
-  policyId: 'refund-over-100',
-  policyRationale: 'Refunds over $100 require manager approval',
-  riskTier: 'medium',
-  toolName: 'send_refund',
-})
+    // Evidence fields the implementor must provide
+    systemId: 'refund-agent-prod',
+    inventoryId: 'ai-inv-refund-agent-v2',  // Your AI inventory record, not orderId
+    policyId: 'refund-over-100',
+    policyRationale: 'Refunds over $100 require manager approval',
+    riskTier: 'medium',
+    toolName: 'send_refund',
+  },
+  { runId: String(runId), suspendPayload: { reason: 'Approval required' } },
+)
 ```
 
 Evidence events are written to the configured HTTP sink (see [Evidence Storage](#evidence-storage) below) as `hitly.evidence.v1` JSON.

--- a/apps/web/content/docs/mobile.mdx
+++ b/apps/web/content/docs/mobile.mdx
@@ -3,7 +3,7 @@ title: Mobile
 description: Reviewer app for iOS and Android — Cloud or hosted login, push, and deep links into a work item.
 ---
 
-The HITL<sub><i>y</i></sub> mobile app is an Expo (React Native) client in `apps/mobile`. It signs into **HITL<sub><i>y</i></sub> Cloud** (`https://cloud.hitly.net`) or a **self-hosted** instance URL, receives device notifications, and opens the approval that needs a decision.
+The HITL<sub><i>y</i></sub> mobile app is an Expo (React Native) client in `apps/mobile`. It signs into a **self-hosted** instance URL, receives device notifications, and opens the approval that needs a decision. (Cloud login at `cloud.hitly.net` is waitlist-only; join at [hitly.net](https://hitly.net).)
 
 Web stays the admin surface for team, rules, people, logs, and API keys. Mobile also has workspace settings, a project list, project inbox, and project config (no key minting).
 
@@ -26,7 +26,7 @@ Do not put a project API key (`hitly_…`) in the mobile app. Those keys are ing
 
 ## Deep links
 
-- Universal link (Cloud): `https://cloud.hitly.net/inbox/{approvalId}`
+- Universal link (self-hosted): `http://localhost:3001/inbox/{approvalId}`
 - Custom scheme: `hitly://inbox/{approvalId}?host={instanceUrl}`
 - Push tap: `data.approvalId` + `data.instanceUrl`
 

--- a/apps/web/content/docs/mobile.mdx
+++ b/apps/web/content/docs/mobile.mdx
@@ -40,7 +40,7 @@ Assignees with a registered Expo token are pushed on ingest, in addition to emai
 {
   "title": "HITLy: send-refund needs a decision",
   "body": "Acme refunds · expires in 15m",
-  "data": { "type": "approval", "approvalId": "apr_…", "instanceUrl": "https://cloud.hitly.net" }
+  "data": { "type": "approval", "approvalId": "apr_…", "instanceUrl": "http://localhost:3001" }
 }
 ```
 

--- a/apps/web/content/docs/projects.mdx
+++ b/apps/web/content/docs/projects.mdx
@@ -11,7 +11,7 @@ A **project** is the integration collector under a workspace. One project maps t
   caption="Projects — one origin per project"
 />
 
-Create projects at `cloud.hitly.net/projects`. The project home (`/projects/:id`) lists that project's work items. Open an item at `/projects/:id/item/:itemId`. Copy the `.env` snippet from Config:
+Create projects at your HITL<sub><i>y</i></sub> app (`http://localhost:3001/projects` when self-hosting). The project home (`/projects/:id`) lists that project's work items. Open an item at `/projects/:id/item/:itemId`. Copy the `.env` snippet from Config:
 
 ```bash
 HITLY_API_URL=http://localhost:3001

--- a/apps/web/content/integrations/langgraph.mdx
+++ b/apps/web/content/integrations/langgraph.mdx
@@ -182,7 +182,7 @@ HITL<sub><i>y</i></sub> must reach `deploymentUrl` to call the resume endpoint. 
 
 | Option | Use it to |
 | --- | --- |
-| `api_url` | HITL<sub><i>y</i></sub> app origin, such as `http://localhost:3001` |
+| `api_url` | HITL<sub><i>y</i></sub> app origin, such as `https://cloud.hitly.net` |
 | `api_key` | Workspace ingest key |
 | `project_id` | Project that owns the API key |
 | `resume_secret` | Project resume secret (for signature verification) |

--- a/apps/web/content/integrations/langgraph.mdx
+++ b/apps/web/content/integrations/langgraph.mdx
@@ -182,7 +182,7 @@ HITL<sub><i>y</i></sub> must reach `deploymentUrl` to call the resume endpoint. 
 
 | Option | Use it to |
 | --- | --- |
-| `api_url` | HITL<sub><i>y</i></sub> app origin, such as `https://cloud.hitly.net` |
+| `api_url` | HITL<sub><i>y</i></sub> app origin, such as `http://localhost:3001` |
 | `api_key` | Workspace ingest key |
 | `project_id` | Project that owns the API key |
 | `resume_secret` | Project resume secret (for signature verification) |

--- a/apps/web/content/integrations/mastra.mdx
+++ b/apps/web/content/integrations/mastra.mdx
@@ -25,25 +25,19 @@ See the runnable project in `examples/mastra` (agent + workflow).
 
 ## Setup
 
+Clone the monorepo and set up the local HITL<sub><i>y</i></sub> app:
+
+```bash
+git clone https://github.com/hitly-net/hitly.git
+cd hitly
+yarn install
+cp apps/app/.env.example apps/app/.env.local
+yarn db:up
+yarn db:migrate
+yarn dev:app  # http://localhost:3001
+```
+
 Create a workspace, [API key](/docs/api), and Mastra [connection](/docs/connections) (`base URL` + token).
-
-Install `@hitly/plugin-mastra`:
-
-```bash
-yarn add @hitly/plugin-mastra
-```
-
-```bash
-npm i @hitly/plugin-mastra
-```
-
-```bash
-pnpm add @hitly/plugin-mastra
-```
-
-```bash
-bun add @hitly/plugin-mastra
-```
 
 Set env:
 
@@ -61,7 +55,7 @@ MASTRA_BASE_URL=http://localhost:4111
 2. In the tool or step `execute`, call `notifyHitlyApproval()`, then `suspend()`.
 3. On resume, call `verifyHitlyResume(resumeData)` then read `resumeData.approved`. If `false`, `bail()` (workflow) or return a rejection (agent tool). Mastra Zod strips unknown keys — `resumeSchema` must `.passthrough()` so the HITLy `hitly` proof survives.
 4. Run `mastra dev` (default `http://localhost:4111`) and HITL<sub><i>y</i></sub> app (`http://localhost:3001`).
-5. Chat with the agent or start the workflow in Studio. Open `cloud.hitly.net/inbox`, accept, watch the run resume.
+5. Chat with the agent or start the workflow in Studio. Open `http://localhost:3001/inbox`, accept, watch the run resume.
 
 ### Workflow step
 
@@ -161,7 +155,7 @@ HITL<sub><i>y</i></sub> must reach `mastraBaseUrl` to call `resume()`. Do not po
 
 | Option | Use it to |
 | --- | --- |
-| `apiUrl` | HITL<sub><i>y</i></sub> app origin, such as `https://cloud.hitly.net` |
+| `apiUrl` | HITL<sub><i>y</i></sub> app origin, such as `http://localhost:3001` |
 | `apiKey` | Workspace ingest key |
 | `projectId` | Project that owns the API key |
 | `mastraBaseUrl` | Origin Mastra server HITL<sub><i>y</i></sub> will call on resume |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #34

## Problem

Design partners following hitly.net/integrations/mastra hit broken paths:
- `@hitly/plugin-mastra` 404s on npm (not published yet)
- `cloud.hitly.net` returns 502 (not running)
- Homepage mentions `createHitlyApprovalStep()` (doesn't exist; live API is `notifyHitlyApproval()`)

## Changes

Updated all public partner-facing docs to reflect the **actual** getting-started path:

1. **Homepage Mastra card** (`plugin-grid.tsx`): Changed `createHitlyApprovalStep()` → `notifyHitlyApproval()`
2. **Mastra integration guide** (`mastra.mdx`):
   - Replaced npm install instructions with monorepo clone + setup
   - Changed `cloud.hitly.net/inbox` → `http://localhost:3001/inbox`
   - Updated `apiUrl` example from `https://cloud.hitly.net` → `http://localhost:3001`
3. **Evidence docs** (`envelope.mdx`): Updated example to use `notifyHitlyApproval()` instead of `createHitlyApprovalStep()`
4. **Projects docs** (`projects.mdx`): Changed "Create projects at cloud.hitly.net/projects" to mention localhost:3001 for self-hosting
5. **README.md**: Changed hosted product line to waitlist-only note, inbox is localhost:3001
6. **LangGraph docs** (`langgraph.mdx`): `api_url` example uses localhost:3001
7. **Mobile docs** (`mobile.mdx`): Deep links and push examples use localhost:3001, Cloud waitlist note added
8. **AGENT.md**: Cloud listed as waitlist-only

## Partner Path Now

```bash
git clone https://github.com/hitly-net/hitly.git
cd hitly
yarn install
yarn db:up && yarn db:migrate
yarn dev:app  # http://localhost:3001
# Create Mastra project, run examples/mastra
```

Inbox: `http://localhost:3001/inbox` (not cloud.hitly.net)

`cloud.hitly.net` is mentioned in docs as **waitlist-only** (join at hitly.net) — no runnable paths or sign-in CTAs.

## Out of Scope

- Standing Cloud back up
- Publishing npm packages
- Temporal plugin (#32 finishing separately)
- S3, mobile (#33), Hermes

## Testing

Docs/copy only. No code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ad2b691-56fd-49a8-8fc9-9768b7427dfd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ad2b691-56fd-49a8-8fc9-9768b7427dfd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

