### PR TITLE
Add cloud.hitly.net waitlist placeholder

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,9 @@
 import { RootProvider } from 'fumadocs-ui/provider/next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import Script from 'next/script'
+import { headers } from 'next/headers'
 import type { ReactNode } from 'react'
+import { CloudPlaceholder } from '@/components/marketing/cloud-placeholder'
 import './globals.css'
 
 const geist = Geist({
@@ -22,7 +24,16 @@ export const metadata = {
   description: 'Approval inbox for agent work — Mastra, Hermes, HTTP, LangGraph, and Temporal.',
 }
 
-export default function Layout({ children }: { children: ReactNode }) {
+function isCloudHost(host: string | null): boolean {
+  if (!host) return false
+  return host === 'cloud.hitly.net' || host === 'www.cloud.hitly.net'
+}
+
+export default async function Layout({ children }: { children: ReactNode }) {
+  const headersList = await headers()
+  const host = headersList.get('host')
+  const showCloudPlaceholder = isCloudHost(host)
+
   return (
     <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col font-sans">
@@ -31,7 +42,9 @@ export default function Layout({ children }: { children: ReactNode }) {
           data-domain="hitly.net"
           strategy="afterInteractive"
         />
-        <RootProvider>{children}</RootProvider>
+        <RootProvider>
+          {showCloudPlaceholder ? <CloudPlaceholder /> : children}
+        </RootProvider>
       </body>
     </html>
   )

--- a/apps/web/components/marketing/cloud-placeholder.tsx
+++ b/apps/web/components/marketing/cloud-placeholder.tsx
@@ -1,0 +1,33 @@
+import { HitlyWordmark } from '@hitly/ui'
+import { WaitlistForm } from './waitlist-form'
+
+export function CloudPlaceholder() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b border-zinc-200 dark:border-zinc-800">
+        <div className="mx-auto max-w-6xl px-6 py-6">
+          <HitlyWordmark className="text-2xl" trademark />
+        </div>
+      </header>
+      <main className="flex flex-1 items-center justify-center px-6 py-12">
+        <div className="w-full max-w-md space-y-8">
+          <div className="text-center">
+            <h1 className="text-3xl font-semibold tracking-tight">HITLy Cloud is not open yet</h1>
+            <p className="mt-3 text-zinc-600 dark:text-zinc-400">
+              Join the waitlist to be notified when the hosted inbox is ready.
+            </p>
+          </div>
+          <WaitlistForm />
+          <p className="text-center text-sm text-zinc-500">
+            <a
+              href="https://hitly.net"
+              className="underline underline-offset-2 hover:text-zinc-800 dark:hover:text-zinc-300"
+            >
+              Learn more about HITLy
+            </a>
+          </p>
+        </div>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the 502 on `cloud.hitly.net` by adding a host-aware placeholder page that serves from the existing marketing app (`@hitly/web`, port 3000).

## Changes

- **New `CloudPlaceholder` component** (`apps/web/components/marketing/cloud-placeholder.tsx`)
  - Displays HITLy wordmark with trademark symbol
  - Shows message: "HITLy Cloud is not open yet"
  - Includes waitlist form (Name, Email, System: Mastra / LangGraph / n8n / Other)
  - Reuses existing `WaitlistForm` component and `/api/waitlist` endpoint
  - Optional link to https://hitly.net for OSS/docs reference

- **Host-aware routing** in root layout (`apps/web/app/layout.tsx`)
  - Detects `cloud.hitly.net` and `www.cloud.hitly.net` via Next.js `headers()`
  - Renders `CloudPlaceholder` for Cloud host, existing marketing pages for `hitly.net`
  - All paths on `cloud.hitly.net` show the placeholder (no `/login`, `/inbox`, `/docs` leakage)

## Implementation Details

- **No new dependencies** or infrastructure changes required
- **Reuses existing waitlist integration** (same n8n webhook via `/api/waitlist`)
- **No Plausible tracking** added for the new domain (existing snippet is `hitly.net` only)
- **No login, signup, billing, or inbox chrome** on the Cloud page
- **Partner path unchanged** (remains `http://localhost:3001`)

## Testing

- Typecheck passes (`yarn typecheck`)
- Ready for nginx to proxy `cloud.hitly.net` to `:3000`

## Out of Scope

- nginx configuration on LAN box (192.168.10.176)
- Standing up Cloud app on `:3003`
- `cloud-test.hitly.net` domain
- README updates (to be done separately if needed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fcad85e-36d2-42fb-9a3b-acd217fe870b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fcad85e-36d2-42fb-9a3b-acd217fe870b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

