### PR TITLE
Serve Cloud placeholder via middleware, not prerendered /

### DIFF
--- a/apps/web/app/cloud/page.tsx
+++ b/apps/web/app/cloud/page.tsx
@@ -1,0 +1,7 @@
+import { CloudPlaceholder } from '@/components/marketing/cloud-placeholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function CloudPage() {
+  return <CloudPlaceholder />
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,9 +1,7 @@
 import { RootProvider } from 'fumadocs-ui/provider/next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import Script from 'next/script'
-import { headers } from 'next/headers'
 import type { ReactNode } from 'react'
-import { CloudPlaceholder } from '@/components/marketing/cloud-placeholder'
 import './globals.css'
 
 const geist = Geist({
@@ -24,16 +22,7 @@ export const metadata = {
   description: 'Approval inbox for agent work — Mastra, Hermes, HTTP, LangGraph, and Temporal.',
 }
 
-function isCloudHost(host: string | null): boolean {
-  if (!host) return false
-  return host === 'cloud.hitly.net' || host === 'www.cloud.hitly.net'
-}
-
-export default async function Layout({ children }: { children: ReactNode }) {
-  const headersList = await headers()
-  const host = headersList.get('host')
-  const showCloudPlaceholder = isCloudHost(host)
-
+export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col font-sans">
@@ -42,9 +31,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
           data-domain="hitly.net"
           strategy="afterInteractive"
         />
-        <RootProvider>
-          {showCloudPlaceholder ? <CloudPlaceholder /> : children}
-        </RootProvider>
+        <RootProvider>{children}</RootProvider>
       </body>
     </html>
   )

--- a/apps/web/components/marketing/cloud-placeholder.tsx
+++ b/apps/web/components/marketing/cloud-placeholder.tsx
@@ -12,9 +12,9 @@ export function CloudPlaceholder() {
       <main className="flex flex-1 items-center justify-center px-6 py-12">
         <div className="w-full max-w-md space-y-8">
           <div className="text-center">
-            <h1 className="text-3xl font-semibold tracking-tight">HITLy Cloud is not open yet</h1>
+            <h1 className="text-3xl font-semibold tracking-tight">Coming soon</h1>
             <p className="mt-3 text-zinc-600 dark:text-zinc-400">
-              Join the waitlist to be notified when the hosted inbox is ready.
+              Join the waitlist for early access.
             </p>
           </div>
           <WaitlistForm />

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+function isCloudHost(host: string | null): boolean {
+  if (!host) return false
+  const hostWithoutPort = host.split(':')[0]
+  return hostWithoutPort === 'cloud.hitly.net' || hostWithoutPort === 'www.cloud.hitly.net'
+}
+
+export function middleware(request: NextRequest) {
+  const host = request.headers.get('host')
+
+  if (!isCloudHost(host)) {
+    return NextResponse.next()
+  }
+
+  const { pathname } = request.nextUrl
+
+  // Allow API routes through
+  if (pathname.startsWith('/api/')) {
+    return NextResponse.next()
+  }
+
+  // Allow Next.js static assets through
+  if (pathname.startsWith('/_next/')) {
+    return NextResponse.next()
+  }
+
+  // Allow static assets (favicon, etc.) through
+  if (
+    pathname === '/favicon.ico' ||
+    pathname.startsWith('/favicon-') ||
+    pathname.startsWith('/apple-touch-icon') ||
+    pathname.endsWith('.png') ||
+    pathname.endsWith('.svg') ||
+    pathname.endsWith('.ico')
+  ) {
+    return NextResponse.next()
+  }
+
+  // Already on /cloud, allow through
+  if (pathname === '/cloud') {
+    return NextResponse.next()
+  }
+
+  // Rewrite all other paths to /cloud
+  const url = request.nextUrl.clone()
+  url.pathname = '/cloud'
+  return NextResponse.rewrite(url)
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!_next/static|_next/image).*)',
+  ],
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #36, `cloud.hitly.net` still serves the prerendered marketing homepage instead of the placeholder.

**Live headers on https://cloud.hitly.net/:**
- `200 OK`
- `x-nextjs-prerender: 1`
- `x-nextjs-cache: HIT`
- Body shows HeroChat + waitlist + plugin grid (marketing site)
- Missing placeholder content

**Root cause:** #36 added a host check in `apps/web/app/layout.tsx` using `headers().get('host')`, but that code doesn't run for statically prerendered pages like `/`.

## Solution

This PR moves the cloud.hitly.net gating logic from the layout to Next.js middleware:

1. **Added `apps/web/middleware.ts`** - Intercepts requests where `Host` is `cloud.hitly.net` or `www.cloud.hitly.net` (strips port) and rewrites ALL paths to `/cloud`
2. **Added `apps/web/app/cloud/page.tsx`** - A dedicated dynamic route (`export const dynamic = 'force-dynamic'`) that renders `CloudPlaceholder`
3. **Simplified `apps/web/app/layout.tsx`** - Removed host check and conditional rendering; middleware now handles routing
4. **Updated placeholder copy** - H1: "Coming soon", subline: "Join the waitlist for early access."
5. **Preserved functionality** - `/api/waitlist` and Next.js static assets (`/_next/*`, favicon) pass through so the waitlist form continues to work

## Placeholder Content

- HITLy™ wordmark
- H1: "Coming soon"
- Subline: "Join the waitlist for early access."
- WaitlistForm component
- Quiet link to hitly.net

## Testing

- ✅ Typecheck passes
- Middleware prevents prerender cache by routing to a dynamic page
- `hitly.net` and `localhost` unchanged
- `cloud.hitly.net` requests rewritten to `/cloud` which is never prerendered

## Changes

- `apps/web/middleware.ts` - New middleware for cloud host routing
- `apps/web/app/cloud/page.tsx` - New dynamic placeholder page
- `apps/web/app/layout.tsx` - Removed host-based conditional logic
- `apps/web/components/marketing/cloud-placeholder.tsx` - Updated copy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b691457b-c607-4420-a72e-36ba548cb75d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b691457b-c607-4420-a72e-36ba548cb75d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

