### PR TITLE
Hermes resumeUrl callback, drop poll loop

### DIFF
--- a/apps/web/content/integrations/hermes.mdx
+++ b/apps/web/content/integrations/hermes.mdx
@@ -13,17 +13,20 @@ Hermes “personas” are **named profiles** (`~/.hermes/profiles/<name>/`, each
 
 Dangerous terminal / `execute_code` calls pause in Hermes `tools/approval.py`. Selecting `security.approval.transport: hitly` replaces the built-in prompt (including Telegram `/approve`).
 
-1. The plugin `present()` POSTs the command to HITL<sub><i>y</i></sub> and **polls** until you decide.
-2. Accept maps to Hermes `once`; reject / timeout maps to `deny`.
-3. Hermes still enforces `approvals.timeout` (default **300 seconds**). HITL<sub><i>y</i></sub> SLA can be longer; the command still denies when Hermes times out.
+1. The plugin `present()` starts a local webhook listener and POSTs the command + `resumeUrl` to HITL<sub><i>y</i></sub>.
+2. The plugin waits on the local callback (not polling HITL<sub><i>y</i></sub>).
+3. Reviewer decides in HITL<sub><i>y</i></sub>.
+4. HITL<sub><i>y</i></sub> POSTs JSON to `resumeUrl`. Accept maps to Hermes `once`; reject / timeout maps to `deny`.
+5. Hermes still enforces `approvals.timeout` (default **300 seconds**). HITL<sub><i>y</i></sub> SLA can be longer; the command still denies when Hermes times out.
 
 ### Kanban workers (autonomous profiles)
 
 The gateway dispatcher spawns `hermes -p <profile>` for board tasks. Those workers **exit** when they need a human — they call `kanban_block` or `kanban_request_review`. That is the HITL path for unattended personas.
 
-1. The plugin POSTs a HITL<sub><i>y</i></sub> card (`kind: kanban`).
-2. Accept → `hermes kanban comment` + `unblock` on the Hermes host (gateway poller).
-3. Reject → comment, leave the card blocked.
+1. The plugin POSTs a HITL<sub><i>y</i></sub> card (`kind: kanban`) with a `resumeUrl` pointing to the local webhook.
+2. Reviewer decides in HITL<sub><i>y</i></sub>.
+3. HITL<sub><i>y</i></sub> POSTs the decision JSON to `resumeUrl`.
+4. Gateway poller receives callback → `hermes kanban comment` + `unblock` (accept) or comment only (reject).
 
 HITL<sub><i>y</i></sub> never POSTs into `hermes dashboard` (localhost-only by default).
 
@@ -65,6 +68,10 @@ security:
 Kanban ingest works even if `transport` is unset. Command routing needs both the plugin **and** `security.approval.transport: hitly`.
 
 `HITLY_API_URL`, `HITLY_API_KEY`, and `HITLY_PROJECT_ID` are env fallbacks for the same settings.
+
+### Resume callback requirements
+
+The `resumeUrl` must be reachable from the HITL<sub><i>y</i></sub> process. Same-machine OSS deployments work fine (`127.0.0.1`). Cloud HITL<sub><i>y</i></sub> cannot reach a laptop `localhost` unless you use a tunnel (ngrok, Tailscale Funnel, etc.).
 
 ## Decision mapping
 

--- a/apps/web/content/integrations/index.mdx
+++ b/apps/web/content/integrations/index.mdx
@@ -10,7 +10,7 @@ Add a framework by writing one adapter against the [envelope](/docs/envelope). Y
 | Plugin | Status | Pause primitive | Resume |
 | --- | --- | --- | --- |
 | [Mastra](/integrations/mastra) | Available | `suspend()` | `run.resume()` / `bail()` |
-| [Hermes](/integrations/hermes) | Available | approval transport / `kanban_block` | origin polls HITL<sub><i>y</i></sub>; kanban comment + unblock |
+| [Hermes](/integrations/hermes) | Available | approval transport / `kanban_block` | POST `{ decision, id, metadata }` to origin callback |
 | [HTTP](/integrations/http) | Available | caller `resumeUrl` | POST `{ decision, id, metadata }` |
 | [n8n](/integrations/n8n) | HTTP today | Wait webhook | POST to `$execution.resumeUrl` |
 | [LangGraph](/integrations/langgraph) | Available | `interrupt()` | `Command({ resume: HumanResponse })` |

--- a/examples/hermes/README.md
+++ b/examples/hermes/README.md
@@ -1,6 +1,6 @@
-# Hitly plugin for Hermes Agent
+# HITLy plugin for Hermes Agent
 
-Drop-in Hermes plugin. Copy this directory to `~/.hermes/plugins/hitly/`, enable it, and (for dangerous-command routing) select the Hitly approval transport.
+Drop-in Hermes plugin. Copy this directory to `~/.hermes/plugins/hitly/`, enable it, and (for dangerous-command routing) select the HITLy approval transport.
 
 ```bash
 cp -R examples/hermes ~/.hermes/plugins/hitly
@@ -22,6 +22,18 @@ security:
     transport_fallback: deny
 ```
 
-Kanban block/review cards are created even if the transport is unset. The gateway process polls Hitly and runs `hermes kanban comment` / `unblock` locally.
+## How it works
+
+### Command approvals
+
+The plugin starts a local webhook server on `127.0.0.1` (random port) when needed. It POSTs the command + `resumeUrl` to HITLy, then waits on the callback (not polling). HITLy POSTs `{ decision, id, metadata }` to the `resumeUrl` when you decide.
+
+### Kanban block/review
+
+Kanban cards are created even if the transport is unset. The gateway process polls the local callback responses and runs `hermes kanban comment` / `unblock` locally.
+
+## Resume callback requirements
+
+The `resumeUrl` must be reachable from the HITLy process. Same-machine OSS deployments work fine (`127.0.0.1`). Cloud HITLy cannot reach a laptop `localhost` unless you use a tunnel (ngrok, Tailscale Funnel, etc.).
 
 See [the Hermes integration guide](https://hitly.net/integrations/hermes).

--- a/examples/hermes/__init__.py
+++ b/examples/hermes/__init__.py
@@ -11,18 +11,24 @@ import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_POLL_INTERVAL = 1.5
-_poller_started = False
-_file_lock = threading.Lock()
-
 _OPEN_STATUSES = frozenset({"pending", "failed_resume"})
 _ACCEPT_DECISIONS = frozenset({"accept", "respond", "edit"})
 _REJECT_DECISIONS = frozenset({"reject", "ignore", "cancel"})
+
+# Callback state: maps approval_id → response
+_callback_responses: dict[str, dict[str, Any]] = {}
+_callback_lock = threading.Lock()
+
+# Webhook server state
+_webhook_server: HTTPServer | None = None
+_webhook_port: int = 0
+_webhook_lock = threading.Lock()
 
 
 def _hermes_home() -> Path:
@@ -107,7 +113,7 @@ def _save_kanban_items(items: list[dict[str, str]]) -> None:
 
 
 def _remember_kanban(task_id: str, approval_id: str, run_id: str, kanban_status: str) -> None:
-    with _file_lock:
+    with threading.Lock():
         items = _load_kanban_items()
         key = (task_id, run_id)
         items = [item for item in items if (item.get("task_id"), item.get("run_id")) != key]
@@ -123,7 +129,7 @@ def _remember_kanban(task_id: str, approval_id: str, run_id: str, kanban_status:
 
 
 def _drop_kanban(approval_id: str) -> None:
-    with _file_lock:
+    with threading.Lock():
         items = [item for item in _load_kanban_items() if item.get("approval_id") != approval_id]
         _save_kanban_items(items)
 
@@ -154,6 +160,62 @@ def _respond(request: Any, choice: str) -> Any:
     raise RuntimeError("Hermes approval request is missing respond()")
 
 
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """Receives HITLy resume callbacks for command approvals."""
+
+    def log_message(self, format: str, *args: Any) -> None:
+        logger.debug(format, *args)
+
+    def do_POST(self) -> None:
+        """Handle POST from HITLy resume."""
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+            body_bytes = self.rfile.read(content_length)
+            body = json.loads(body_bytes.decode("utf-8"))
+
+            approval_id = body.get("id")
+            if not approval_id:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b'{"error": "Missing id"}')
+                return
+
+            with _callback_lock:
+                _callback_responses[approval_id] = body
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok": true}')
+        except Exception as e:
+            logger.exception("Callback handler error")
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": str(e)}).encode("utf-8"))
+
+
+def _ensure_webhook_server() -> int:
+    """Start local webhook server if not running. Returns the port."""
+    global _webhook_server, _webhook_port
+    with _webhook_lock:
+        if _webhook_server is not None:
+            return _webhook_port
+
+        # Find available port
+        server = HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+        _webhook_port = server.server_address[1]
+        _webhook_server = server
+
+        def serve():
+            logger.info(f"HITLy callback server listening on port {_webhook_port}")
+            _webhook_server.serve_forever()
+
+        thread = threading.Thread(target=serve, name="hitly-webhook", daemon=True)
+        thread.start()
+
+        return _webhook_port
+
+
 def present(ctx: Any, request: Any) -> Any:
     settings = _settings(ctx)
     if not settings["api_url"] or not settings["api_key"] or not settings["project_id"]:
@@ -168,6 +230,10 @@ def present(ctx: Any, request: Any) -> Any:
     session_key = str(_attr(request, "session_key", "sessionKey", default="") or "")
     pattern_key = str(_attr(request, "pattern_key", "patternKey", default="") or "")
     run_id = request_id or session_key or f"hermes-{int(time.time())}"
+
+    # Start webhook server and build resumeUrl
+    port = _ensure_webhook_server()
+    resume_url = f"http://127.0.0.1:{port}/hitly-callback"
 
     try:
         created = _request_json(
@@ -186,6 +252,8 @@ def present(ctx: Any, request: Any) -> Any:
                 "command": command,
                 "description": description or None,
                 "expiresAt": _iso_expiry(timeout),
+                "resumeUrl": resume_url,
+                "metadata": {"runId": run_id},
             },
             idempotency_key=request_id or run_id,
         )
@@ -198,22 +266,27 @@ def present(ctx: Any, request: Any) -> Any:
         logger.error("Hitly ingest returned no approval id")
         return _respond(request, "deny")
 
+    # Wait for callback
     deadline = time.monotonic() + max(timeout - 2, 5)
     while time.monotonic() < deadline:
-        try:
-            status = _request_json(settings, "GET", f"/api/v1/approvals/{approval_id}", timeout=15)
-        except Exception:
-            logger.exception("Hitly command poll failed")
-            time.sleep(_POLL_INTERVAL)
-            continue
-        state = str(status.get("status") or "")
-        decision = status.get("decision")
-        if state in _OPEN_STATUSES:
-            time.sleep(_POLL_INTERVAL)
-            continue
-        if decision in _ACCEPT_DECISIONS:
-            return _respond(request, _accept_choice(request))
-        return _respond(request, "deny")
+        with _callback_lock:
+            response = _callback_responses.get(approval_id)
+        if response:
+            decision = response.get("decision")
+            if decision in _ACCEPT_DECISIONS:
+                # Clean up
+                with _callback_lock:
+                    _callback_responses.pop(approval_id, None)
+                return _respond(request, _accept_choice(request))
+            elif decision in _REJECT_DECISIONS:
+                with _callback_lock:
+                    _callback_responses.pop(approval_id, None)
+                return _respond(request, "deny")
+        time.sleep(0.5)
+
+    # Timeout
+    with _callback_lock:
+        _callback_responses.pop(approval_id, None)
     return _respond(request, "deny")
 
 
@@ -233,6 +306,11 @@ def _ingest_kanban(
         logger.error("Hitly kanban ingest skipped: missing settings")
         return
     run_id = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip() or f"{task_id}:{kanban_status}"
+
+    # Kanban also uses callback for resume
+    port = _ensure_webhook_server()
+    resume_url = f"http://127.0.0.1:{port}/hitly-callback"
+
     try:
         created = _request_json(
             settings,
@@ -248,6 +326,8 @@ def _ingest_kanban(
                 "kanbanStatus": kanban_status,
                 "reason": reason,
                 "blockKind": block_kind,
+                "resumeUrl": resume_url,
+                "metadata": {"taskId": task_id, "runId": run_id},
             },
             idempotency_key=f"{task_id}:{run_id}",
         )
@@ -270,59 +350,58 @@ def _hermes_kanban(*args: str) -> None:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"hermes kanban {' '.join(args)} failed")
 
 
-def _apply_kanban_decision(item: dict[str, str], status: dict[str, Any]) -> None:
+def _apply_kanban_decision(item: dict[str, str], decision_body: dict[str, Any]) -> None:
     task_id = item["task_id"]
-    decision = status.get("decision")
-    response = status.get("response")
+    decision = decision_body.get("decision")
+    response = decision_body.get("response")
     note = response.strip() if isinstance(response, str) and response.strip() else ""
     if decision in _ACCEPT_DECISIONS:
-        _hermes_kanban("comment", task_id, note or "Approved in Hitly.")
+        _hermes_kanban("comment", task_id, note or "Approved in HITLy.")
         _hermes_kanban("unblock", task_id)
         _drop_kanban(item["approval_id"])
         return
-    if decision in _REJECT_DECISIONS or str(status.get("status") or "") in {"expired", "cancelled"}:
-        _hermes_kanban("comment", task_id, note or f"Rejected in Hitly ({decision or status.get('status')}).")
+    if decision in _REJECT_DECISIONS:
+        _hermes_kanban("comment", task_id, note or f"Rejected in HITLy ({decision}).")
         _drop_kanban(item["approval_id"])
         return
 
 
-def _poller_loop(ctx: Any) -> None:
+def _kanban_poller_loop(ctx: Any) -> None:
+    """Poll for kanban callback responses and apply them."""
     while True:
         try:
-            settings = _settings(ctx)
-            if settings["api_url"] and settings["api_key"]:
-                with _file_lock:
-                    items = list(_load_kanban_items())
-                for item in items:
+            items = list(_load_kanban_items())
+            for item in items:
+                approval_id = item.get("approval_id")
+                if not approval_id:
+                    continue
+
+                with _callback_lock:
+                    decision_body = _callback_responses.get(approval_id)
+
+                if decision_body:
                     try:
-                        status = _request_json(
-                            settings,
-                            "GET",
-                            f"/api/v1/approvals/{item['approval_id']}",
-                            timeout=15,
-                        )
-                    except Exception:
-                        logger.exception("Hitly kanban poll failed for %s", item.get("approval_id"))
-                        continue
-                    if str(status.get("status") or "") in _OPEN_STATUSES:
-                        continue
-                    try:
-                        _apply_kanban_decision(item, status)
+                        _apply_kanban_decision(item, decision_body)
+                        with _callback_lock:
+                            _callback_responses.pop(approval_id, None)
                     except Exception:
                         logger.exception("Hermes kanban resume failed for %s", item.get("task_id"))
         except Exception:
             logger.exception("Hitly kanban poller iteration failed")
-        time.sleep(5)
+        time.sleep(2)
 
 
-def _maybe_start_poller(ctx: Any) -> None:
-    global _poller_started
-    if _poller_started:
+_kanban_poller_started = False
+
+
+def _maybe_start_kanban_poller(ctx: Any) -> None:
+    global _kanban_poller_started
+    if _kanban_poller_started:
         return
     if os.environ.get("HERMES_KANBAN_TASK") or os.environ.get("HERMES_CRON_SESSION"):
         return
-    _poller_started = True
-    thread = threading.Thread(target=_poller_loop, args=(ctx,), name="hitly-kanban-poller", daemon=True)
+    _kanban_poller_started = True
+    thread = threading.Thread(target=_kanban_poller_loop, args=(ctx,), name="hitly-kanban-poller", daemon=True)
     thread.start()
 
 
@@ -355,4 +434,4 @@ def register(ctx: Any) -> None:
 
     ctx.register_hook("kanban_task_blocked", on_blocked)
     ctx.register_hook("post_tool_call", on_tool)
-    _maybe_start_poller(ctx)
+    _maybe_start_kanban_poller(ctx)

--- a/examples/hermes/__init__.py
+++ b/examples/hermes/__init__.py
@@ -1,4 +1,4 @@
-"""Hitly plugin for Hermes Agent — approval transport + kanban block/review."""
+"""HITLy plugin for Hermes Agent — approval transport + kanban block/review."""
 
 from __future__ import annotations
 
@@ -84,7 +84,7 @@ def _request_json(
             return json.loads(raw) if raw else {}
     except urllib.error.HTTPError as error:
         snippet = error.read().decode("utf-8", errors="replace")[:500]
-        raise RuntimeError(f"Hitly {method} {path} failed ({error.code}): {snippet}") from error
+        raise RuntimeError(f"HITLy {method} {path} failed ({error.code}): {snippet}") from error
 
 
 def _iso_expiry(seconds: float) -> str:
@@ -219,7 +219,7 @@ def _ensure_webhook_server() -> int:
 def present(ctx: Any, request: Any) -> Any:
     settings = _settings(ctx)
     if not settings["api_url"] or not settings["api_key"] or not settings["project_id"]:
-        logger.error("Hitly transport is missing api_url, api_key, or project_id")
+        logger.error("HITLy transport is missing api_url, api_key, or project_id")
         return _respond(request, "deny")
 
     timeout = float(_attr(request, "timeout", default=300) or 300)
@@ -258,12 +258,12 @@ def present(ctx: Any, request: Any) -> Any:
             idempotency_key=request_id or run_id,
         )
     except Exception:
-        logger.exception("Hitly command ingest failed")
+        logger.exception("HITLy command ingest failed")
         return _respond(request, "deny")
 
     approval_id = created.get("id")
     if not isinstance(approval_id, str) or not approval_id:
-        logger.error("Hitly ingest returned no approval id")
+        logger.error("HITLy ingest returned no approval id")
         return _respond(request, "deny")
 
     # Wait for callback
@@ -303,7 +303,7 @@ def _ingest_kanban(
         return
     settings = _settings(ctx)
     if not settings["api_url"] or not settings["api_key"] or not settings["project_id"]:
-        logger.error("Hitly kanban ingest skipped: missing settings")
+        logger.error("HITLy kanban ingest skipped: missing settings")
         return
     run_id = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip() or f"{task_id}:{kanban_status}"
 
@@ -332,7 +332,7 @@ def _ingest_kanban(
             idempotency_key=f"{task_id}:{run_id}",
         )
     except Exception:
-        logger.exception("Hitly kanban ingest failed for %s", task_id)
+        logger.exception("HITLy kanban ingest failed for %s", task_id)
         return
     approval_id = created.get("id")
     if isinstance(approval_id, str) and approval_id:
@@ -387,7 +387,7 @@ def _kanban_poller_loop(ctx: Any) -> None:
                     except Exception:
                         logger.exception("Hermes kanban resume failed for %s", item.get("task_id"))
         except Exception:
-            logger.exception("Hitly kanban poller iteration failed")
+            logger.exception("HITLy kanban poller iteration failed")
         time.sleep(2)
 
 

--- a/examples/hermes/plugin.yaml
+++ b/examples/hermes/plugin.yaml
@@ -1,6 +1,6 @@
 name: hitly
 version: 1.0.0
-description: Route Hermes command approvals and kanban block/review pauses to the Hitly inbox
+description: Route Hermes command approvals and kanban block/review pauses to the HITLy inbox
 manifest_version: 2
 homepage: https://hitly.net/integrations/hermes
 license: Apache-2.0
@@ -8,12 +8,12 @@ config_schema:
   api_url:
     type: str
     default: ""
-    description: Hitly app origin, e.g. http://localhost:3001
+    description: HITLy app origin, e.g. http://localhost:3001
   api_key:
     type: str
     default: ""
-    description: Hitly project API key
+    description: HITLy project API key
   project_id:
     type: str
     default: ""
-    description: Hitly project id
+    description: HITLy project id

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "db:down": "docker compose -f docker-compose.yml down",
     "db:generate": "yarn workspace @hitly/db db:generate",
     "db:migrate": "yarn workspace @hitly/db db:migrate",
-    "test": "yarn workspace @hitly/mail test && yarn workspace @hitly/core test && yarn workspace @hitly/app test && yarn workspace @hitly/mobile test && yarn workspace @hitly/example-evidence-http test && yarn workspace @hitly/plugin-langgraph test && yarn workspace @hitly/plugin-temporal test",
+    "test": "yarn workspace @hitly/mail test && yarn workspace @hitly/core test && yarn workspace @hitly/app test && yarn workspace @hitly/mobile test && yarn workspace @hitly/example-evidence-http test && yarn workspace @hitly/plugin-langgraph test && yarn workspace @hitly/plugin-temporal test && yarn workspace @hitly/plugin-hermes test",
     "build": "turbo build",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -1,3 +1,11 @@
 # @hitly/plugin-hermes
 
-Hermes Agent adapter: ingest a command-approval or kanban block/review payload. Resume is a no-op — the Hermes plugin polls Hitly and applies the decision locally (command transport `present()`, or `hermes kanban comment` + `unblock`).
+Hermes Agent adapter for HITLy: ingest command-approval or kanban block/review payloads with a `resumeUrl`. Resume POSTs the decision JSON to the origin's callback URL.
+
+The drop-in Hermes plugin ([examples/hermes](../../examples/hermes)) starts a local webhook listener and waits on the callback. Same pattern as HTTP: `{ decision, id, metadata }`.
+
+## Resume callback
+
+`resumeUrl` is required for resume. If missing, resume fails with an error. The origin should wait on the callback, not poll HITLy.
+
+The `resumeUrl` must be reachable from the HITLy process. Same-machine OSS deployments work fine (`127.0.0.1`). Cloud HITLy cannot reach a laptop `localhost` unless you use a tunnel (ngrok, Tailscale Funnel, etc.).

--- a/packages/plugin-hermes/package.json
+++ b/packages/plugin-hermes/package.json
@@ -23,12 +23,14 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "test": "tsx --test src/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hitly/core": "*"
   },
   "devDependencies": {
+    "tsx": "^4.23.12",
     "typescript": "^5.9.2"
   }
 }

--- a/packages/plugin-hermes/src/index.test.ts
+++ b/packages/plugin-hermes/src/index.test.ts
@@ -53,7 +53,7 @@ describe('@hitly/plugin-hermes', () => {
       assert.equal(result.origin.resumeHandle.resumeUrl, 'http://localhost:8080/kanban-callback')
     })
 
-    it('should ingest without resumeUrl (legacy poll mode)', () => {
+    it('should throw when resumeUrl is missing', () => {
       const raw = {
         plugin: 'hermes',
         projectId: 'prj_123',
@@ -61,10 +61,9 @@ describe('@hitly/plugin-hermes', () => {
         command: 'ls -la',
       }
 
-      const result = hermesPlugin.ingest(raw)
-
-      assert.equal(result.origin.resumeHandle.resumeUrl, undefined)
-      assert.equal(result.origin.runId, 'cmd_abc')
+      assert.throws(() => {
+        hermesPlugin.ingest(raw)
+      }, /Hermes ingest requires resumeUrl/)
     })
 
     it('should throw when runId is missing for command', () => {
@@ -73,6 +72,7 @@ describe('@hitly/plugin-hermes', () => {
         projectId: 'prj_123',
         kind: 'command',
         command: 'test',
+        resumeUrl: 'http://localhost:8080/callback',
       }
 
       assert.throws(() => {
@@ -85,6 +85,7 @@ describe('@hitly/plugin-hermes', () => {
         plugin: 'hermes',
         projectId: 'prj_123',
         kind: 'kanban',
+        resumeUrl: 'http://localhost:8080/callback',
       }
 
       assert.throws(() => {
@@ -172,7 +173,14 @@ describe('@hitly/plugin-hermes', () => {
       assert.equal(body.response, 'Not approved at this time')
     })
 
-    it('should return error when resumeUrl is missing', async () => {
+    it('should return error when resumeUrl is missing and not call fetch', async () => {
+      const mockFetch = mock.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => '{}',
+      })) as unknown as typeof fetch
+      global.fetch = mockFetch
+
       const origin: OriginRef = {
         plugin: 'hermes',
         projectId: 'prj_123',
@@ -192,6 +200,10 @@ describe('@hitly/plugin-hermes', () => {
       assert.equal(result.status, 0)
       assert(result.error?.includes('Hermes resume requires resumeUrl'))
       assert(result.error?.includes('Origin should wait on callback'))
+      
+      // Verify fetch was never called
+      const mockCalls = (mockFetch as any).mock.calls
+      assert.equal(mockCalls.length, 0, 'fetch should not be called when resumeUrl is missing')
     })
 
     it('should handle HTTP errors from resumeUrl', async () => {

--- a/packages/plugin-hermes/src/index.test.ts
+++ b/packages/plugin-hermes/src/index.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, mock } from 'node:test'
+import { strict as assert } from 'node:assert'
+import { hermesPlugin } from './index'
+import type { DecisionPayload, OriginRef, ResumeResponse } from '@hitly/core'
+
+describe('@hitly/plugin-hermes', () => {
+  describe('ingest', () => {
+    it('should ingest a Hermes command approval with resumeUrl', () => {
+      const raw = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        kind: 'command',
+        runId: 'cmd_abc',
+        requestId: 'req_xyz',
+        command: 'rm -rf /important',
+        description: 'Delete important files',
+        resumeUrl: 'http://localhost:8080/hitly-callback',
+        metadata: { sessionId: 'sess_123' },
+      }
+
+      const result = hermesPlugin.ingest(raw)
+
+      assert.equal(result.action.name, 'hermes-approval')
+      assert.equal(result.action.args.command, 'rm -rf /important')
+      assert.equal(result.allowedActions.accept, true)
+      assert.equal(result.allowedActions.reject, true)
+      assert.equal(result.origin.plugin, 'hermes')
+      assert.equal(result.origin.projectId, 'prj_123')
+      assert.equal(result.origin.runId, 'cmd_abc')
+      assert.equal(result.origin.resumeHandle.resumeUrl, 'http://localhost:8080/hitly-callback')
+      assert.deepEqual(result.origin.resumeHandle.metadata, { sessionId: 'sess_123' })
+      assert.deepEqual(result.metadata, { sessionId: 'sess_123' })
+    })
+
+    it('should ingest a Hermes kanban block with resumeUrl', () => {
+      const raw = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        kind: 'kanban',
+        taskId: 'task_456',
+        profileName: 'assistant-dev',
+        kanbanStatus: 'blocked',
+        reason: 'Need approval for API call',
+        resumeUrl: 'http://localhost:8080/kanban-callback',
+      }
+
+      const result = hermesPlugin.ingest(raw)
+
+      assert.equal(result.action.name, 'kanban-block')
+      assert.equal(result.action.args.taskId, 'task_456')
+      assert.equal(result.allowedActions.respond, true)
+      assert.equal(result.origin.plugin, 'hermes')
+      assert.equal(result.origin.resumeHandle.resumeUrl, 'http://localhost:8080/kanban-callback')
+    })
+
+    it('should ingest without resumeUrl (legacy poll mode)', () => {
+      const raw = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        runId: 'cmd_abc',
+        command: 'ls -la',
+      }
+
+      const result = hermesPlugin.ingest(raw)
+
+      assert.equal(result.origin.resumeHandle.resumeUrl, undefined)
+      assert.equal(result.origin.runId, 'cmd_abc')
+    })
+
+    it('should throw when runId is missing for command', () => {
+      const raw = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        kind: 'command',
+        command: 'test',
+      }
+
+      assert.throws(() => {
+        hermesPlugin.ingest(raw)
+      }, /Hermes command ingest requires runId/)
+    })
+
+    it('should throw when taskId is missing for kanban', () => {
+      const raw = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        kind: 'kanban',
+      }
+
+      assert.throws(() => {
+        hermesPlugin.ingest(raw)
+      }, /Hermes kanban ingest requires taskId/)
+    })
+  })
+
+  describe('resume', () => {
+    it('should POST accept to resumeUrl', async () => {
+      const mockFetch = mock.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ success: true }),
+      })) as unknown as typeof fetch
+      global.fetch = mockFetch
+
+      const origin: OriginRef = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        runId: 'cmd_abc',
+        resumeHandle: {
+          kind: 'command',
+          runId: 'cmd_abc',
+          resumeUrl: 'http://localhost:8080/hitly-callback',
+          metadata: { sessionId: 'sess_123' },
+          approvalId: 'apr_xyz',
+        },
+      }
+
+      const payload: DecisionPayload = {
+        decision: 'accept',
+      }
+
+      const result = (await hermesPlugin.resume(origin, payload)) as ResumeResponse
+
+      const mockCalls = (mockFetch as any).mock.calls
+      assert.equal(mockCalls.length, 1)
+      const call = mockCalls[0]
+      assert.equal(call.arguments[0], 'http://localhost:8080/hitly-callback')
+      const fetchOptions = call.arguments[1] as RequestInit
+      assert.equal(fetchOptions.method, 'POST')
+      const body = JSON.parse(fetchOptions.body as string)
+      assert.equal(body.decision, 'accept')
+      assert.equal(body.id, 'apr_xyz')
+      assert.deepEqual(body.metadata, { sessionId: 'sess_123' })
+
+      assert.equal(result.status, 200)
+      assert.deepEqual(result.body, { success: true })
+    })
+
+    it('should POST reject with response to resumeUrl', async () => {
+      const mockFetch = mock.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => '{}',
+      })) as unknown as typeof fetch
+      global.fetch = mockFetch
+
+      const origin: OriginRef = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        runId: 'task_456:blocked',
+        resumeHandle: {
+          kind: 'kanban',
+          taskId: 'task_456',
+          runId: 'task_456:blocked',
+          resumeUrl: 'http://localhost:8080/kanban-callback',
+          metadata: {},
+        },
+      }
+
+      const payload: DecisionPayload = {
+        decision: 'reject',
+        response: 'Not approved at this time',
+      }
+
+      await hermesPlugin.resume(origin, payload)
+
+      const mockCalls = (mockFetch as any).mock.calls
+      const call = mockCalls[0]
+      const fetchOptions = call.arguments[1] as RequestInit
+      const body = JSON.parse(fetchOptions.body as string)
+      assert.equal(body.decision, 'reject')
+      assert.equal(body.response, 'Not approved at this time')
+    })
+
+    it('should return error when resumeUrl is missing', async () => {
+      const origin: OriginRef = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        runId: 'cmd_abc',
+        resumeHandle: {
+          kind: 'command',
+          runId: 'cmd_abc',
+        },
+      }
+
+      const payload: DecisionPayload = {
+        decision: 'accept',
+      }
+
+      const result = (await hermesPlugin.resume(origin, payload)) as ResumeResponse
+
+      assert.equal(result.status, 0)
+      assert(result.error?.includes('Hermes resume requires resumeUrl'))
+      assert(result.error?.includes('Origin should wait on callback'))
+    })
+
+    it('should handle HTTP errors from resumeUrl', async () => {
+      const mockFetch = mock.fn(async () => ({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      })) as unknown as typeof fetch
+      global.fetch = mockFetch
+
+      const origin: OriginRef = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        runId: 'cmd_abc',
+        resumeHandle: {
+          kind: 'command',
+          runId: 'cmd_abc',
+          resumeUrl: 'http://localhost:8080/hitly-callback',
+          metadata: {},
+        },
+      }
+
+      const payload: DecisionPayload = {
+        decision: 'accept',
+      }
+
+      const result = (await hermesPlugin.resume(origin, payload)) as ResumeResponse
+
+      assert.equal(result.status, 500)
+      assert(result.error?.includes('Hermes resume failed (500)'))
+      assert(result.error?.includes('Internal Server Error'))
+    })
+
+    it('should include editedArgs when provided', async () => {
+      const mockFetch = mock.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => '{}',
+      })) as unknown as typeof fetch
+      global.fetch = mockFetch
+
+      const origin: OriginRef = {
+        plugin: 'hermes',
+        projectId: 'prj_123',
+        runId: 'cmd_abc',
+        resumeHandle: {
+          kind: 'command',
+          runId: 'cmd_abc',
+          resumeUrl: 'http://localhost:8080/hitly-callback',
+          metadata: {},
+        },
+      }
+
+      const payload: DecisionPayload = {
+        decision: 'edit',
+        editedArgs: { command: 'ls -l' },
+      }
+
+      await hermesPlugin.resume(origin, payload)
+
+      const mockCalls = (mockFetch as any).mock.calls
+      const call = mockCalls[0]
+      const fetchOptions = call.arguments[1] as RequestInit
+      const body = JSON.parse(fetchOptions.body as string)
+      assert.equal(body.decision, 'edit')
+      assert.deepEqual(body.editedArgs, { command: 'ls -l' })
+    })
+  })
+
+  describe('healthcheck', () => {
+    it('should return ok', async () => {
+      const result = await hermesPlugin.healthcheck({
+        plugin: 'hermes',
+      })
+
+      assert.equal(result, 'ok')
+    })
+  })
+})

--- a/packages/plugin-hermes/src/index.ts
+++ b/packages/plugin-hermes/src/index.ts
@@ -76,6 +76,9 @@ export function ingestHermes(raw: unknown): ApprovalEnvelope & { origin: OriginR
     sessionKey ??
     ''
 
+  if (!resumeUrl) {
+    throw new Error('Hermes ingest requires resumeUrl')
+  }
   if (kind === 'kanban' && !taskId) {
     throw new Error('Hermes kanban ingest requires taskId')
   }
@@ -135,7 +138,8 @@ export function ingestHermes(raw: unknown): ApprovalEnvelope & { origin: OriginR
         requestId,
         taskId,
         runId,
-        ...(resumeUrl ? { resumeUrl, metadata } : {}),
+        resumeUrl,
+        metadata,
       },
       details: originDetails({
         kind,

--- a/packages/plugin-hermes/src/index.ts
+++ b/packages/plugin-hermes/src/index.ts
@@ -28,6 +28,8 @@ export interface HermesIngestPayload {
   kanbanStatus?: 'blocked' | 'review'
   reason?: string
   blockKind?: string
+  resumeUrl?: string
+  metadata?: Record<string, unknown>
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -65,6 +67,8 @@ export function ingestHermes(raw: unknown): ApprovalEnvelope & { origin: OriginR
   const kanbanStatus = body.kanbanStatus === 'review' ? 'review' : 'blocked'
   const reason = optionalString(body.reason)
   const blockKind = optionalString(body.blockKind)
+  const resumeUrl = optionalString(body.resumeUrl)
+  const metadata = asRecord(body.metadata)
   const runId =
     optionalString(body.runId) ??
     requestId ??
@@ -119,6 +123,7 @@ export function ingestHermes(raw: unknown): ApprovalEnvelope & { origin: OriginR
       respond: kind === 'kanban',
     }),
     contextMarkdown: contextMarkdown || undefined,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     expiresAt: typeof body.expiresAt === 'string' ? body.expiresAt : undefined,
     origin: {
       plugin: 'hermes',
@@ -130,6 +135,7 @@ export function ingestHermes(raw: unknown): ApprovalEnvelope & { origin: OriginR
         requestId,
         taskId,
         runId,
+        ...(resumeUrl ? { resumeUrl, metadata } : {}),
       },
       details: originDetails({
         kind,
@@ -151,11 +157,53 @@ export async function resumeHermes(
   payload: DecisionPayload,
   _credentials?: ConnectionCredentials,
 ): Promise<ResumeResponse> {
-  return {
-    resumeData: payload as unknown as Record<string, unknown>,
-    status: 200,
-    body: { ok: true, kind: origin.resumeHandle.kind ?? origin.details?.kind ?? 'command' },
+  const resumeUrl = String(origin.resumeHandle.resumeUrl ?? '')
+  if (!resumeUrl) {
+    return {
+      resumeData: {},
+      status: 0,
+      body: null,
+      error: 'Hermes resume requires resumeUrl. Origin should wait on callback, not poll HITLy.',
+    }
   }
+
+  const metadata = asRecord(origin.resumeHandle.metadata)
+  const resumeData: Record<string, unknown> = {
+    decision: payload.decision,
+    metadata,
+  }
+  const approvalId = optionalString(origin.resumeHandle.approvalId)
+  if (approvalId) resumeData.id = approvalId
+  if (payload.editedArgs) resumeData.editedArgs = payload.editedArgs
+  if (payload.response) resumeData.response = payload.response
+
+  const response = await fetch(resumeUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(resumeData),
+  })
+
+  const text = await response.text()
+  let body: unknown = text || null
+  if (text) {
+    try {
+      body = JSON.parse(text) as unknown
+    } catch {
+      body = text
+    }
+  }
+
+  if (!response.ok) {
+    const snippet = text.length > 500 ? `${text.slice(0, 500)}…` : text
+    return {
+      resumeData,
+      status: response.status,
+      body,
+      error: `Hermes resume failed (${response.status}): ${snippet}`,
+    }
+  }
+
+  return { resumeData, status: response.status, body }
 }
 
 export async function healthcheckHermes(_credentials: ConnectionCredentials): Promise<'ok' | 'error'> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #38

Implements resumeUrl callback mechanism for Hermes plugin, matching the HTTP plugin pattern. Removes the GET-polling approach in favor of origin-owned webhooks.

## Acceptance Bar ✅

- ✅ **Ingest must reject missing resumeUrl** - HTTP 400, same as HTTP plugin. No legacy poll mode.
- ✅ **Resume**: POST resumeUrl with `{ decision, id, metadata }` - same shape as HTTP
- ✅ **Missing resumeUrl in resume** (defensive): returns status 0 + error, **does not POST**, fetch not called
- ✅ **Rewrite examples/hermes**: off GET-polling, uses local webhook listener
- ✅ **Docs**: dropped "origin polls HITLy" language
- ✅ **Tests** (`tsx --test`): 
  - ✅ Accept → POSTs `{ decision, id, metadata }`
  - ✅ Reject → POSTs `{ decision, id, metadata }`
  - ✅ Missing resumeUrl at ingest → throws error
  - ✅ Missing resumeUrl at resume → error, **fetch never called**
- ✅ **Brand**: HITLy (never Hitly, never cloud-test.hitly.net)
- ✅ **api_url**: stays localhost:3001

## Changes

### Plugin (`@hitly/plugin-hermes`)
- **Ingest requires `resumeUrl`** - throws `'Hermes ingest requires resumeUrl'` if missing
- Accept optional `metadata` in ingest payload
- Store both in envelope `resumeHandle` (always present after ingest)
- Implement `resumeHermes` to POST `{ decision, id, metadata }` to resumeUrl
- **Defensive resume**: if resumeUrl somehow missing, return error status 0, no POST attempt
- Comprehensive test coverage: 11 tests, all passing

### Origin plugin (`examples/hermes`)
- Start local HTTP webhook server on `127.0.0.1` (random port)
- Pass webhook URL as `resumeUrl` at ingest (required)
- Wait on callback, **not GET-polling HITLy**
- Command approval uses callback
- Kanban block/review uses callback with poller to apply decisions

### Documentation
- Updated `hermes.mdx` - callback flow, removed all polling references
- Updated `index.mdx` - resume column: "POST `{ decision, id, metadata }` to origin callback"
- Updated plugin README - callback requirements, resumeUrl mandatory
- Updated example README - webhook approach
- Document: resumeUrl must be reachable from HITLy process

### Tests
- `packages/plugin-hermes/src/index.test.ts` (11/11 passing)
- ✅ Ingest with resumeUrl (command & kanban)
- ✅ **Ingest without resumeUrl throws error**
- ✅ Resume accept - POSTs to callback
- ✅ Resume reject with response
- ✅ **Missing resumeUrl at resume - returns error, verifies fetch NOT called**
- ✅ HTTP errors from callback
- ✅ editedArgs support
- ✅ Validation: missing runId, missing taskId
- Wired into package and root `yarn test`

## Not Included
- ❌ No changes to #33 (mobile)
- ❌ No S3 integration changes
- ❌ No Temporal plugin changes

## Testing

```bash
# Plugin tests (11/11 pass)
yarn workspace @hitly/plugin-hermes test

# Typecheck
yarn typecheck
```

**Test Results**: All 11 tests passing ✅

## Validation Behavior

### Ingest (matching HTTP plugin)
```typescript
// Missing resumeUrl → throws immediately
throw new Error('Hermes ingest requires resumeUrl')
```

### Resume (defensive)
```typescript
// If resumeUrl somehow missing from stored data
// Returns error, does NOT call fetch
return {
  resumeData: {},
  status: 0,
  body: null,
  error: 'Hermes resume requires resumeUrl. Origin should wait on callback, not poll HITLy.'
}
```

## Callback Requirements

The `resumeUrl` must be reachable from the HITLy process:
- ✅ Same-machine OSS: `127.0.0.1` works fine
- ❌ Cloud HITLy → laptop localhost: requires tunnel (ngrok, Tailscale Funnel)

## Related

- Follows HTTP plugin pattern: `packages/plugin-http/src/index.ts`
- Integration docs: `/integrations/hermes`
- Example plugin: `examples/hermes`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c097d422-c998-4063-b5e1-80031422d83e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c097d422-c998-4063-b5e1-80031422d83e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

