### PR TITLE
Docs: dedicated S3 evidence page

### DIFF
--- a/apps/web/content/docs/envelope.mdx
+++ b/apps/web/content/docs/envelope.mdx
@@ -145,25 +145,7 @@ See `examples/evidence-http` for a reference HTTP receiver.
 
 ### S3 Sink Configuration
 
-- **S3 Endpoint**: S3-compatible endpoint URL (e.g., `http://127.0.0.1:3902` for Garage, `https://s3.eu-west-1.amazonaws.com` for AWS)
-- **S3 Region**: Region name (e.g., `local`, `us-east-1`, `eu-west-1`, `auto` for Cloudflare R2)
-- **S3 Bucket**: Bucket name (dedicated to evidence; not mixed with application assets)
-- **S3 Access Key ID**: IAM or service account access key
-- **S3 Secret Access Key**: Corresponding secret key
-- **S3 Prefix**: Optional prefix for object keys (e.g., `hitly/` to organize events under a folder)
-- **Force Path Style**: Defaults to enabled for non-AWS endpoints (Garage, R2, on-premises S3). Uses `example.com/bucket/key` instead of virtual-host `bucket.example.com/key`.
-
-Each evidence event is stored as a JSON file named `{event_id}.json` (or `{prefix}/{event_id}.json` if prefix is set). The `store_uri` in the receipt is the HTTPS URL to that S3 object.
-
-HITLy uses AWS Signature Version 4 (SigV4) to authenticate PutObject requests. Credentials are encrypted in the project configuration.
-
-**Supported S3-compatible services:**
-- **AWS S3**: Enable versioning and Block Public Access. Use a dedicated bucket for evidence.
-- **Cloudflare R2**: Set region to `auto`. R2 does not support Object Lock (community request only); do not require Object Lock.
-- **Garage** (local development): See `examples/evidence-s3` for a docker compose setup.
-- **On-premises S3** (Ceph, Cloudian): Set `forcePathStyle: true`.
-
-See `examples/evidence-s3` for a Garage docker compose setup and configuration guide.
+See [S3 evidence](/docs/s3) for S3 configuration fields, local setup with Garage, production settings (AWS S3, Cloudflare R2, on-premises Ceph/Cloudian), and `examples/evidence-s3`.
 
 HITLy stores a **receipt index only**, not the payload as system of record. Evidence lifecycle:
 

--- a/apps/web/content/docs/meta.json
+++ b/apps/web/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Docs",
-  "pages": ["index", "self-host", "inbox", "envelope", "api", "projects", "governance", "mobile"]
+  "pages": ["index", "self-host", "inbox", "envelope", "s3", "api", "projects", "governance", "mobile"]
 }

--- a/apps/web/content/docs/s3.mdx
+++ b/apps/web/content/docs/s3.mdx
@@ -1,0 +1,85 @@
+---
+title: S3 evidence
+description: Store hitly.evidence.v1 events in S3-compatible object storage.
+---
+
+HITL<sub><i>y</i></sub> keeps a receipt index only. The payload lives in a sink you own. **S3** is a first-class sink: AWS S3, Cloudflare R2, Garage, or on-prem Ceph/Cloudian. The **HTTP** sink stays the OSS reference receiver — see [Envelope](/docs/envelope#evidence-storage) and `examples/evidence-http`.
+
+Do not use MinIO. The community repo is archived; they push proprietary AIStor. The local stand-in is Garage.
+
+## What S3 stores
+
+Each evidence event is one object: `{event_id}.json` (or `{prefix}/{event_id}.json`). HITL<sub><i>y</i></sub> authenticates with SigV4 PutObject. `store_uri` is the http(s) object URL, never `file://`.
+
+| Event | Sink failure |
+| --- | --- |
+| `requested` | Fail-open. Ingest continues. |
+| `decided` | **Fail-closed.** Origin is not resumed. Item stays pending. |
+| `resumed` / `resume_failed` | Fail-open. |
+
+`type=s3` with a missing endpoint, bucket, or keys throws. Decide stays pending.
+
+## Configure a project
+
+Self-host Config: `http://localhost:3001/projects/:id/config`.
+
+| Field | What to set |
+| --- | --- |
+| Evidence sink type | `S3` |
+| Endpoint | S3 API URL. Garage: `http://127.0.0.1:3902`. AWS: `https://s3.eu-west-1.amazonaws.com`. |
+| Region | `local` (Garage), `us-east-1` / `eu-west-1` (AWS), `auto` (R2) |
+| Bucket | Dedicated evidence bucket. Not mixed with app assets. |
+| Access key / secret | Encrypted on the project. Password fields. Leave blank on later saves to keep. |
+| Prefix | Optional, e.g. `hitly/` |
+| Force path-style | Defaults **on** when the endpoint is not `amazonaws.com`. Garage and most on-prem need `example.com/bucket/key`, not `bucket.example.com/key`. |
+
+Credentials live on the project, not on the origin `.env`.
+
+There is no **Test Evidence Sink** button for S3 yet (HTTP only). Confirm with a real decide, or list the bucket.
+
+## Local: Garage
+
+`examples/evidence-s3` is the local S3 stand-in.
+
+```bash
+cd examples/evidence-s3
+docker compose up -d
+docker compose exec garage garage key new hitly-evidence
+docker compose exec garage garage bucket create evidence
+docker compose exec garage garage bucket allow --read --write evidence --key GK...
+```
+
+S3 API listens at `http://127.0.0.1:3902`. Set the project fields above (region `local`, bucket `evidence`, path-style on).
+
+```bash
+aws --endpoint-url http://127.0.0.1:3902 --region local s3 ls s3://evidence/
+```
+
+Full walkthrough: [`examples/evidence-s3/README.md`](https://github.com/hitly-net/hitly/blob/main/examples/evidence-s3/README.md).
+
+## Production
+
+**AWS S3.** Dedicated bucket, versioning on, Block Public Access. Endpoint `https://s3.{region}.amazonaws.com`. IAM: PutObject only. Path-style off (virtual-host is the AWS default).
+
+**Cloudflare R2.** Endpoint `https://{account-id}.r2.cloudflarestorage.com`. Region `auto`. R2 has no Object Lock — do not require it.
+
+**On-prem (Ceph, Cloudian).** Your S3 API URL. Path-style on unless the vendor says otherwise.
+
+Enterprise WORM is customer S3 Object Lock, not this sink.
+
+## Fail-closed
+
+If PutObject fails on `decided` (4xx, 5xx, or hang over 5s), HITL<sub><i>y</i></sub> does not POST resume. The item stays pending. Fix the bucket, then decide again.
+
+## Receipts
+
+HITL<sub><i>y</i></sub> stores `event_id`, `content_sha256`, `store_uri`, `stored_at`. **View evidence receipt** shows for http(s) `store_uri` only. S3 http(s) URLs qualify.
+
+## What this page is not
+
+- Not a replacement for the HTTP sink
+- Not MinIO
+- Not Object Lock / WORM
+- Not a hosted Cloud login. Runnable examples stay on localhost.
+
+Schema and HTTP sink: [Envelope](/docs/envelope#evidence-storage).

--- a/examples/evidence-s3/README.md
+++ b/examples/evidence-s3/README.md
@@ -1,5 +1,7 @@
 # S3 Evidence Storage with Garage
 
+See [S3 evidence](/docs/s3) for configuration, production settings, and fail-closed behavior.
+
 This example demonstrates using an S3-compatible storage backend for HITLy evidence events. It uses [Garage](https://garagehq.deuxfleurs.fr/), a lightweight, open-source, S3-compatible object storage server designed for self-hosting and geo-distributed deployments.
 
 Garage is ideal for local development and simulates production S3 environments (AWS S3, Cloudflare R2, on-premises Ceph/Cloudian) without requiring cloud credentials.

--- a/examples/evidence-s3/README.md
+++ b/examples/evidence-s3/README.md
@@ -92,11 +92,9 @@ In your HITLy project settings (Config tab), set:
 
 Save the configuration.
 
-### 4. Test the Evidence Sink
+### 4. Verify the Configuration
 
-In your HITLy project config page, after saving the S3 configuration, click **Test Evidence Sink**. If successful, HITLy will POST a test evidence event to your Garage bucket.
-
-Alternatively, trigger a real approval flow in your agent and check that evidence events are stored.
+There is no **Test Evidence Sink** button for S3 yet (HTTP only). Confirm with a real decide, or list the bucket with the `aws` CLI.
 
 ### 5. Verify Stored Objects
 

--- a/examples/evidence-s3/README.md
+++ b/examples/evidence-s3/README.md
@@ -198,7 +198,7 @@ Each evidence event is stored as a JSON file named `{event_id}.json`. The `store
 - Ensure Force Path Style is `true` in HITLy config
 - Verify the region in HITLy matches the Garage region (`local`)
 
-**Test evidence sink returns 5xx:**
+**Decide or PutObject returns 5xx:**
 - Check Garage logs: `docker compose logs garage`
 - Verify the bucket exists: `docker compose exec garage garage bucket list`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #43

Adds a dedicated documentation page for S3 evidence storage configuration and setup.

## Changes

- **New page:** `/docs/s3` with comprehensive S3 sink documentation
  - Configuration fields table (endpoint, region, bucket, credentials, prefix, path-style)
  - Local development setup with Garage
  - Production settings (AWS S3, Cloudflare R2, on-prem Ceph/Cloudian)
  - Fail-closed behavior and receipts
  - Explicitly states "Do not use MinIO" with Garage as the local stand-in

- **Updated navigation:** Inserted "S3 evidence" after "Envelope" in docs nav

- **Updated Envelope docs:** Replaced S3 field dump with a short pointer to `/docs/s3`, keeping HTTP section intact

- **Updated example README:** Added link to `/docs/s3` at the top of `examples/evidence-s3/README.md`
  - Fixed step 4: Removed incorrect **Test Evidence Sink** button reference (button is HTTP only)
  - Matches `/docs/s3` guidance: confirm with a real decide, or `aws s3 ls` the bucket

## Testing

- Local dev server confirms `/docs/s3` renders correctly
- Navigation order verified: shows after Envelope
- Envelope page HTTP section remains in full
- No new MinIO mentions in edited docs (only the intended "Do not use MinIO" line in s3.mdx)

## CI Status

✅ CI passed successfully

Ready for Test acceptance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7056f3e-e5dd-4817-860e-6759d520ae70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7056f3e-e5dd-4817-860e-6759d520ae70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

