### PR TITLE
Fix inbox edit decisions and add theme picker

### DIFF
--- a/apps/app/actions/projects.ts
+++ b/apps/app/actions/projects.ts
@@ -19,7 +19,7 @@ import { newId } from '@/lib/ids'
 import { parseProjectConfig, saveProjectConfig } from '@/lib/project-config'
 import { canAdminProject, canDecide, canManageWorkspace, getProjectAccess } from '@/lib/rbac'
 import { requireDb, requireTenantWorkspaceId } from '@/lib/tenant'
-import { encodeTenantJson } from '@/lib/tenant-crypto'
+import { decodeTenantJson, encodeTenantJson } from '@/lib/tenant-crypto'
 
 function revalidateWorkItem(approvalId: string, projectId: string) {
   revalidatePath('/inbox')
@@ -407,7 +407,15 @@ export async function delegateWorkItem(approvalId: string, formData: FormData) {
   })
 }
 
-export async function decideWorkItem(approvalId: string, formData: FormData) {
+export async function decideWorkItem(
+  approvalId: string,
+  input: {
+    decision: string
+    response?: string
+    editedArgsJson?: string
+    returnTo?: string
+  },
+) {
   return withAppTenant(async ({ user, role, workspace }) => {
     const database = requireDb()
     const approvalRows = await database
@@ -423,25 +431,43 @@ export async function decideWorkItem(approvalId: string, formData: FormData) {
       workspaceRole: role,
     })
     if (!canDecide(access)) throw new Error('You cannot decide this work item')
-    const decision = String(formData.get('decision') ?? '')
-    const response = String(formData.get('response') ?? '').trim()
-    const editedRaw = String(formData.get('editedArgs') ?? '').trim()
+    const decision = String(input.decision ?? '')
+    const response = String(input.response ?? '').trim()
+    const editedRaw = String(input.editedArgsJson ?? '').trim()
     let editedArgs: Record<string, unknown> | undefined
     if (editedRaw) {
-      editedArgs = JSON.parse(editedRaw) as Record<string, unknown>
+      try {
+        const parsed = JSON.parse(editedRaw) as unknown
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          editedArgs = parsed as Record<string, unknown>
+        }
+      } catch {
+        throw new Error('Edited args must be valid JSON')
+      }
+    }
+    if (decision === 'edit' && !editedArgs) {
+      const envelope = await decodeTenantJson(workspace.id, approval.envelope)
+      const args = (envelope.action as { args?: unknown } | undefined)?.args
+      if (args && typeof args === 'object' && !Array.isArray(args)) {
+        editedArgs = args as Record<string, unknown>
+      }
     }
     const { decideApproval, parseDecisionBody } = await import('@/lib/approvals')
     const payload = parseDecisionBody({ decision, response: response || undefined, editedArgs })
-    if (!payload) throw new Error('Invalid decision')
+    if (!payload) {
+      throw new Error(decision === 'edit' ? 'Edit requires edited args JSON' : 'Invalid decision')
+    }
     const result = await decideApproval({ approvalId, actorUserId: user.id, payload, workspaceId: workspace.id })
+    const returnForm = new FormData()
+    if (input.returnTo) returnForm.set('returnTo', input.returnTo)
     if (result.error && result.status === 500) {
-      const returnPath = workItemReturnPath(formData, approval)
+      const returnPath = workItemReturnPath(returnForm, approval)
       const errorParam = encodeURIComponent(result.error)
       redirect(`${returnPath}?error=${errorParam}`)
     }
     throwUnlessConflict(result)
     revalidateWorkItem(approvalId, approval.projectId)
-    redirect(workItemReturnPath(formData, approval))
+    redirect(workItemReturnPath(returnForm, approval))
   })
 }
 

--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @source '../../../packages/ui/src';
+@custom-variant dark (&:where(.dark, .dark *));
 
 .markdown {
   @apply text-sm leading-6 text-zinc-700 dark:text-zinc-300;

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -1,7 +1,10 @@
 import { Geist, Geist_Mono } from 'next/font/google'
+import { cookies } from 'next/headers'
 import type { ReactNode } from 'react'
 import './globals.css'
 import { FaviconUpdater } from '@/components/favicon-updater'
+import { ThemeSync } from '@/components/theme-picker'
+import { parseTheme, THEME_COOKIE } from '@/lib/theme'
 
 const geist = Geist({ subsets: ['latin'], variable: '--font-sans' })
 const geistMono = Geist_Mono({ subsets: ['latin'], variable: '--font-mono' })
@@ -11,10 +14,16 @@ export const metadata = {
   description: 'HITLy — approval inbox for agent work',
 }
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const theme = parseTheme((await cookies()).get(THEME_COOKIE)?.value)
+  const htmlClass = [geist.variable, geistMono.variable, theme === 'dark' ? 'dark' : '']
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
+    <html lang="en" className={htmlClass} suppressHydrationWarning>
       <body className="h-dvh overflow-hidden bg-zinc-50 font-sans text-zinc-950 antialiased dark:bg-zinc-950 dark:text-zinc-50">
+        <ThemeSync />
         <FaviconUpdater />
         {children}
       </body>

--- a/apps/app/app/settings/profile/page.tsx
+++ b/apps/app/app/settings/profile/page.tsx
@@ -1,4 +1,5 @@
 import { AppShell } from '@/components/app-shell'
+import { ThemePicker } from '@/components/theme-picker'
 import { getAppContext } from '@/lib/context'
 
 export const metadata = { title: 'Profile' }
@@ -19,6 +20,11 @@ export default async function ProfilePage() {
           <br />
           {user.email}
         </p>
+      </div>
+      <h2 className="mt-10 text-lg font-semibold">Theme</h2>
+      <p className="mt-1 text-sm text-zinc-500">Saved in this browser. System follows your OS appearance.</p>
+      <div className="mt-3">
+        <ThemePicker />
       </div>
     </AppShell>
   )

--- a/apps/app/components/app-toolbar.tsx
+++ b/apps/app/components/app-toolbar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { ChevronLeft } from 'lucide-react'
 import { switchWorkspace } from '@/actions/workspace'
-import { SignOutButton } from '@/components/sign-out-button'
+import { UserMenu } from '@/components/user-menu'
 import {
   toolbarBackHref,
   toolbarPage,
@@ -80,9 +80,8 @@ export function AppToolbar({
           </option>
         ))}
       </select>
-      <div className="ml-auto flex items-center gap-3 text-sm">
-        <Link href="/settings/profile">{userName}</Link>
-        <SignOutButton />
+      <div className="ml-auto">
+        <UserMenu userName={userName} />
       </div>
     </header>
   )

--- a/apps/app/components/sign-out-button.tsx
+++ b/apps/app/components/sign-out-button.tsx
@@ -2,12 +2,12 @@
 
 import { useRouter } from 'next/navigation'
 
-export function SignOutButton() {
+export function SignOutButton({ className }: { className?: string }) {
   const router = useRouter()
   return (
     <button
       type="button"
-      className="text-sm text-zinc-500 hover:text-zinc-900"
+      className={className ?? 'text-sm text-zinc-500 hover:text-zinc-900'}
       onClick={async () => {
         await fetch('/api/auth/sign-out', { method: 'POST' })
         router.push('/login')

--- a/apps/app/components/theme-picker.tsx
+++ b/apps/app/components/theme-picker.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { Monitor, Moon, Sun } from 'lucide-react'
+import {
+  applyTheme,
+  parseTheme,
+  readThemeCookie,
+  writeThemeCookie,
+  type Theme,
+} from '@/lib/theme'
+
+const OPTIONS: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+]
+
+const themeStore = {
+  listeners: new Set<() => void>(),
+
+  getSnapshot() {
+    return readThemeCookie()
+  },
+
+  subscribe(callback: () => void) {
+    themeStore.listeners.add(callback)
+    return () => themeStore.listeners.delete(callback)
+  },
+
+  notify() {
+    themeStore.listeners.forEach((listener) => listener())
+  },
+
+  set(value: Theme) {
+    writeThemeCookie(value)
+    applyTheme(value)
+    themeStore.notify()
+  },
+}
+
+export function ThemeSync() {
+  const theme = useSyncExternalStore(themeStore.subscribe, themeStore.getSnapshot, () => 'system' as Theme)
+
+  useEffect(() => {
+    applyTheme(theme)
+    if (theme !== 'system') return
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => applyTheme('system')
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
+  }, [theme])
+
+  return null
+}
+
+export function ThemePicker({ compact = false }: { compact?: boolean }) {
+  const theme = useSyncExternalStore(themeStore.subscribe, themeStore.getSnapshot, () => 'system' as Theme)
+
+  const select = useCallback((value: string) => {
+    themeStore.set(parseTheme(value))
+  }, [])
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme"
+      className={compact ? 'grid grid-cols-3 gap-1' : 'flex max-w-md gap-1 rounded-md border border-zinc-200 p-1 dark:border-zinc-700'}
+    >
+      {OPTIONS.map((option) => {
+        const Icon = option.icon
+        const selected = theme === option.value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => select(option.value)}
+            className={
+              selected
+                ? 'inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-zinc-900 px-2 text-xs font-medium text-white dark:bg-zinc-100 dark:text-zinc-900'
+                : 'inline-flex h-8 items-center justify-center gap-1.5 rounded-md px-2 text-xs text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900'
+            }
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/app/components/user-menu.tsx
+++ b/apps/app/components/user-menu.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useId, useRef, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { SignOutButton } from '@/components/sign-out-button'
+import { ThemePicker } from '@/components/theme-picker'
+
+export function UserMenu({ userName }: { userName: string }) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(event: PointerEvent) {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setOpen(false)
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-900"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-controls={menuId}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {userName}
+        <ChevronDown className="h-3.5 w-3.5 text-zinc-500" />
+      </button>
+      {open ? (
+        <div
+          id={menuId}
+          role="menu"
+          className="absolute right-0 z-20 mt-1 w-56 rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+        >
+          <Link
+            href="/settings/profile"
+            role="menuitem"
+            className="block rounded-md px-2 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-900"
+            onClick={() => setOpen(false)}
+          >
+            Profile
+          </Link>
+          <p className="mt-2 px-2 text-xs font-medium text-zinc-500">Theme</p>
+          <div className="mt-1 px-1">
+            <ThemePicker compact />
+          </div>
+          <div className="mt-2 border-t border-zinc-200 pt-2 dark:border-zinc-800">
+            <SignOutButton className="block w-full rounded-md px-2 py-1.5 text-left text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-900 dark:hover:text-zinc-100" />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/app/components/work-item-client.tsx
+++ b/apps/app/components/work-item-client.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
-import { useFormStatus } from 'react-dom'
+import { useEffect, useState, useTransition } from 'react'
 import type { AllowedActions, Decision } from '@hitly/core'
+import { decideWorkItem } from '@/actions/projects'
 
 export function RefreshOnFocus() {
   const router = useRouter()
@@ -21,23 +21,82 @@ export function RefreshOnFocus() {
   return null
 }
 
-export function WorkItemDecisionButtons({ allowed }: { allowed: AllowedActions }) {
-  const { pending } = useFormStatus()
+export function WorkItemDecideForm({
+  approvalId,
+  returnTo,
+  allowed,
+  initialEditedArgs,
+}: {
+  approvalId: string
+  returnTo: string
+  allowed: AllowedActions
+  initialEditedArgs: string
+}) {
+  const [editedArgs, setEditedArgs] = useState(initialEditedArgs)
+  const [response, setResponse] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+  const allowEdit = Boolean(allowed.edit)
+  const allowRespond = Boolean(allowed.respond)
+  const decisions = (Object.entries(allowed) as [Decision, boolean][])
+    .filter(([, on]) => on)
+    .map(([decision]) => decision)
+
+  function submit(decision: Decision) {
+    setError(null)
+    startTransition(async () => {
+      try {
+        await decideWorkItem(approvalId, {
+          decision,
+          returnTo,
+          response: allowRespond ? response : undefined,
+          editedArgsJson: allowEdit ? editedArgs : undefined,
+        })
+      } catch (err) {
+        // Next.js redirect() throws; ignore redirect digests.
+        if (err && typeof err === 'object' && 'digest' in err && String(err.digest).startsWith('NEXT_REDIRECT')) {
+          return
+        }
+        setError(err instanceof Error ? err.message : 'Decision failed')
+      }
+    })
+  }
+
   return (
-    <div className="flex flex-wrap gap-2">
-      {(Object.entries(allowed) as [Decision, boolean][])
-        .filter(([, on]) => on)
-        .map(([decision]) => (
+    <div className="mt-6 flex max-w-xl flex-col gap-3">
+      {allowEdit ? (
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium">Edited args</span>
+          <span className="text-xs text-zinc-500">Change a value, then click Edit.</span>
+          <textarea
+            value={editedArgs}
+            onChange={(event) => setEditedArgs(event.target.value)}
+            className="min-h-24 rounded-md border border-zinc-200 px-3 py-2 font-mono text-xs dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </label>
+      ) : null}
+      {allowRespond ? (
+        <input
+          value={response}
+          onChange={(event) => setResponse(event.target.value)}
+          placeholder="Response"
+          className="h-10 rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+        />
+      ) : null}
+      {error ? <p className="text-sm text-red-600 dark:text-red-400">{error}</p> : null}
+      <div className="flex flex-wrap gap-2">
+        {decisions.map((decision) => (
           <button
             key={decision}
-            name="decision"
-            value={decision}
+            type="button"
             disabled={pending}
+            onClick={() => submit(decision)}
             className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium capitalize text-white disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900"
           >
             {decision}
           </button>
         ))}
+      </div>
     </div>
   )
 }

--- a/apps/app/components/work-item-detail.tsx
+++ b/apps/app/components/work-item-detail.tsx
@@ -4,12 +4,12 @@ import { and, desc, eq } from 'drizzle-orm'
 import { isOpenApprovalStatus, type ApprovalEnvelope, type OriginRef, type PluginId } from '@hitly/core'
 import { approvals, decisionRecords, projectMemberships, users } from '@hitly/db/schema'
 import { Badge, PluginBadge, PluginMark } from '@hitly/ui'
-import { decideWorkItem, delegateWorkItem, retryWorkItem } from '@/actions/projects'
+import { delegateWorkItem, retryWorkItem } from '@/actions/projects'
 import { AppShell } from '@/components/app-shell'
 import { ContextMarkdown } from '@/components/context-markdown'
 import { ForceCancelButton } from '@/components/force-cancel-button'
 import { JsonDisclosure } from '@/components/json-disclosure'
-import { RefreshOnFocus, WorkItemDecisionButtons } from '@/components/work-item-client'
+import { RefreshOnFocus, WorkItemDecideForm } from '@/components/work-item-client'
 import { withAppTenant } from '@/lib/context'
 import { originFields, envelopeMetadata } from '@/lib/origin'
 import { canDecide, getProjectAccess } from '@/lib/rbac'
@@ -285,24 +285,12 @@ export async function WorkItemDetail({
         <p className="mt-4 text-sm text-amber-700">This work item has expired.</p>
       ) : null}
       {canAct && !expired ? (
-        <form action={decideWorkItem.bind(null, approval.id)} className="mt-6 flex max-w-xl flex-col gap-3">
-          <input type="hidden" name="returnTo" value={returnTo} />
-          {allowed.edit ? (
-            <textarea
-              name="editedArgs"
-              placeholder='Edited args JSON, e.g. {"amount": 10}'
-              className="min-h-20 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
-            />
-          ) : null}
-          {allowed.respond ? (
-            <input
-              name="response"
-              placeholder="Response"
-              className="h-10 rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
-            />
-          ) : null}
-          <WorkItemDecisionButtons allowed={allowed} />
-        </form>
+        <WorkItemDecideForm
+          approvalId={approval.id}
+          returnTo={returnTo}
+          allowed={allowed}
+          initialEditedArgs={JSON.stringify(envelope.action.args ?? {}, null, 2)}
+        />
       ) : null}
       {approval.status === 'failed_resume' && canDecide(access) ? (
         <form action={retryWorkItem.bind(null, approval.id)} className="mt-4">

--- a/apps/app/lib/approvals.spine.test.ts
+++ b/apps/app/lib/approvals.spine.test.ts
@@ -711,21 +711,18 @@ test('edit without delta / final_sha256 is invalid', async () => {
   })
   assert.ok(ingestResult.ok)
 
-  // Try to decide with edit but no delta/final_sha256
   const payloadNoDelta = parseDecisionBody({
     decision: 'edit',
-    // Missing editedArgs and final_sha256
   })
-  assert.equal(payloadNoDelta, null, 'parseDecisionBody should reject edit without editedArgs/final_sha256')
+  assert.equal(payloadNoDelta, null, 'parseDecisionBody should reject edit without editedArgs')
 
-  // Valid edit should have both editedArgs and final_sha256
   const payloadWithDelta = parseDecisionBody({
     decision: 'edit',
     editedArgs: { amount: 50 },
-    final_sha256: 'abc123',
   })
-  assert.ok(payloadWithDelta, 'parseDecisionBody should accept edit with editedArgs and final_sha256')
+  assert.ok(payloadWithDelta, 'parseDecisionBody should accept edit with editedArgs')
   assert.equal(payloadWithDelta.decision, 'edit')
+  assert.deepEqual(payloadWithDelta.editedArgs, { amount: 50 })
 })
 
 test('evidence fields round-trip through ingest/decide', async () => {

--- a/apps/app/lib/approvals.ts
+++ b/apps/app/lib/approvals.ts
@@ -568,18 +568,17 @@ export async function retryResume(args: { approvalId: string; workspaceId?: stri
 export function parseDecisionBody(body: Record<string, unknown>): DecisionPayload | null {
   if (!isDecision(body.decision)) return null
   const decision = body.decision as Decision
-  
-  // Edit requires both editedArgs (delta) and final_sha256
-  if (decision === 'edit') {
-    const hasEditedArgs = body.editedArgs && typeof body.editedArgs === 'object'
-    const hasFinalSha = typeof body.final_sha256 === 'string' && body.final_sha256.length > 0
-    if (!hasEditedArgs || !hasFinalSha) return null
-  }
-  
+  const editedArgs =
+    body.editedArgs !== null && typeof body.editedArgs === 'object' && !Array.isArray(body.editedArgs)
+      ? (body.editedArgs as Record<string, unknown>)
+      : undefined
+
+  // Edit is the delta JSON from the reviewer. Hitly hashes it into evidence final_sha256.
+  if (decision === 'edit' && !editedArgs) return null
+
   return {
     decision,
-    editedArgs:
-      body.editedArgs && typeof body.editedArgs === 'object' ? (body.editedArgs as Record<string, unknown>) : undefined,
+    editedArgs,
     response: typeof body.response === 'string' ? body.response : undefined,
   }
 }

--- a/apps/app/lib/theme.ts
+++ b/apps/app/lib/theme.ts
@@ -1,0 +1,26 @@
+export const THEME_COOKIE = 'hitly-theme'
+
+export const THEMES = ['light', 'dark', 'system'] as const
+
+export type Theme = (typeof THEMES)[number]
+
+export function parseTheme(value: string | null | undefined): Theme {
+  return value === 'light' || value === 'dark' ? value : 'system'
+}
+
+export function applyTheme(theme: Theme) {
+  const dark =
+    theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  document.documentElement.classList.toggle('dark', dark)
+  document.documentElement.style.colorScheme = dark ? 'dark' : 'light'
+}
+
+export function readThemeCookie() {
+  if (typeof document === 'undefined') return 'system' as const
+  const match = document.cookie.split('; ').find((part) => part.startsWith(`${THEME_COOKIE}=`))
+  return parseTheme(match?.slice(THEME_COOKIE.length + 1))
+}
+
+export function writeThemeCookie(theme: Theme) {
+  document.cookie = `${THEME_COOKIE}=${theme}; path=/; max-age=31536000; samesite=lax`
+}


### PR DESCRIPTION
## Summary
- Fix work-item **Edit** so edited args are sent as a plain server-action payload (React 19 FormData was dropping the JSON), with the field prefilled from the proposed action.
- Relax `parseDecisionBody` so edits only require `editedArgs`; Hitly still hashes `final_sha256` when writing evidence.
- Add light / dark / system theme picker in the toolbar user menu and on Profile, using a cookie + class-based `dark` variant (no layout `<script>` tags).

## Test plan
- [ ] Open a pending Mastra refund item with edit allowed; confirm Edited args is prefilled; click **Edit** and confirm the decision succeeds and resume continues.
- [ ] Click **Accept** / **Reject** on another item and confirm those still work.
- [ ] Open the user menu → switch Light / Dark / System; reload and confirm the choice sticks.
- [ ] Confirm Profile also shows the theme control.
- [ ] Confirm no “script tag while rendering React component” overlay on load.


Made with [Cursor](https://cursor.com)