### PR TITLE
Allowlisted typed edit fields, not a JSON box

### DIFF
--- a/apps/app/actions/projects.ts
+++ b/apps/app/actions/projects.ts
@@ -425,13 +425,21 @@ export async function decideWorkItem(approvalId: string, formData: FormData) {
     if (!canDecide(access)) throw new Error('You cannot decide this work item')
     const decision = String(formData.get('decision') ?? '')
     const response = String(formData.get('response') ?? '').trim()
+    const editReason = String(formData.get('editReason') ?? '').trim()
+    const editReasonText = String(formData.get('editReasonText') ?? '').trim()
     const editedRaw = String(formData.get('editedArgs') ?? '').trim()
     let editedArgs: Record<string, unknown> | undefined
     if (editedRaw) {
       editedArgs = JSON.parse(editedRaw) as Record<string, unknown>
     }
     const { decideApproval, parseDecisionBody } = await import('@/lib/approvals')
-    const payload = parseDecisionBody({ decision, response: response || undefined, editedArgs })
+    const payload = parseDecisionBody({
+      decision,
+      response: response || undefined,
+      editedArgs,
+      editReason: editReason || undefined,
+      editReasonText: editReasonText || undefined,
+    })
     if (!payload) throw new Error('Invalid decision')
     const result = await decideApproval({ approvalId, actorUserId: user.id, payload, workspaceId: workspace.id })
     if (result.error && result.status === 500) {

--- a/apps/app/components/editable-fields-form.tsx
+++ b/apps/app/components/editable-fields-form.tsx
@@ -1,0 +1,297 @@
+'use client'
+
+import { useState } from 'react'
+import type { EditableFieldSpec, EditReasonConfig } from '@hitly/core'
+
+const DEFAULT_EDIT_REASON_OPTIONS = [
+  'customer_request',
+  'pricing_correction',
+  'policy_exception',
+  'other',
+]
+
+export function EditableFieldsForm({
+  fields,
+  originalArgs,
+  editReasonConfig,
+}: {
+  fields: Record<string, EditableFieldSpec>
+  originalArgs: Record<string, unknown>
+  editReasonConfig?: EditReasonConfig
+}) {
+  const [values, setValues] = useState<Record<string, unknown>>(() => {
+    const initial: Record<string, unknown> = {}
+    for (const [key, spec] of Object.entries(fields)) {
+      const orig = originalArgs[key]
+      if (spec.type === 'array' && Array.isArray(orig)) {
+        initial[key] = [...orig]
+      } else if (orig !== undefined) {
+        initial[key] = orig
+      } else if (spec.type === 'bool') {
+        initial[key] = false
+      } else if (spec.type === 'array') {
+        initial[key] = []
+      } else if (spec.type === 'int' || spec.type === 'float') {
+        initial[key] = spec.min ?? 0
+      } else {
+        initial[key] = ''
+      }
+    }
+    return initial
+  })
+
+  const [editReason, setEditReason] = useState('')
+  const [editReasonText, setEditReasonText] = useState('')
+  const [showPreview, setShowPreview] = useState(false)
+
+  const dropdownConfig = editReasonConfig?.dropdown === false ? null : editReasonConfig?.dropdown ?? {}
+  const textConfig = editReasonConfig?.text === false ? null : editReasonConfig?.text ?? {}
+
+  function updateValue(key: string, value: unknown) {
+    setValues((prev) => ({ ...prev, [key]: value }))
+  }
+
+  function updateArrayItem(key: string, index: number, value: unknown) {
+    setValues((prev) => {
+      const arr = Array.isArray(prev[key]) ? [...(prev[key] as unknown[])] : []
+      arr[index] = value
+      return { ...prev, [key]: arr }
+    })
+  }
+
+  function addArrayItem(key: string, itemType: 'string' | 'int' | 'float') {
+    setValues((prev) => {
+      const arr = Array.isArray(prev[key]) ? [...(prev[key] as unknown[])] : []
+      if (itemType === 'string') arr.push('')
+      else arr.push(0)
+      return { ...prev, [key]: arr }
+    })
+  }
+
+  function removeArrayItem(key: string, index: number) {
+    setValues((prev) => {
+      const arr = Array.isArray(prev[key]) ? [...(prev[key] as unknown[])] : []
+      arr.splice(index, 1)
+      return { ...prev, [key]: arr }
+    })
+  }
+
+  const mergedArgs = { ...originalArgs, ...values }
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(fields).map(([key, spec]) => {
+        const value = values[key]
+        const label = spec.label ?? key
+
+        if (spec.type === 'string') {
+          return (
+            <div key={key}>
+              <label htmlFor={`field-${key}`} className="block text-sm font-medium">
+                {label}
+              </label>
+              <input
+                type="text"
+                id={`field-${key}`}
+                name={`editedArgs.${key}`}
+                value={String(value ?? '')}
+                onChange={(e) => updateValue(key, e.target.value)}
+                minLength={spec.minLength}
+                maxLength={spec.maxLength}
+                className="mt-1 h-10 w-full rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+              />
+            </div>
+          )
+        }
+
+        if (spec.type === 'int' || spec.type === 'float') {
+          return (
+            <div key={key}>
+              <label htmlFor={`field-${key}`} className="block text-sm font-medium">
+                {label}
+              </label>
+              <input
+                type="number"
+                id={`field-${key}`}
+                name={`editedArgs.${key}`}
+                value={Number(value ?? 0)}
+                onChange={(e) => {
+                  const val = spec.type === 'int' ? parseInt(e.target.value, 10) : parseFloat(e.target.value)
+                  updateValue(key, isNaN(val) ? 0 : val)
+                }}
+                step={spec.type === 'int' ? 1 : spec.step ?? 'any'}
+                min={spec.min}
+                max={spec.max}
+                className="mt-1 h-10 w-full rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+              />
+            </div>
+          )
+        }
+
+        if (spec.type === 'bool') {
+          return (
+            <div key={key} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id={`field-${key}`}
+                name={`editedArgs.${key}`}
+                checked={Boolean(value)}
+                onChange={(e) => updateValue(key, e.target.checked)}
+                className="h-4 w-4"
+              />
+              <label htmlFor={`field-${key}`} className="text-sm font-medium">
+                {label}
+              </label>
+            </div>
+          )
+        }
+
+        if (spec.type === 'enum') {
+          const options = spec.options ?? []
+          return (
+            <div key={key}>
+              <label htmlFor={`field-${key}`} className="block text-sm font-medium">
+                {label}
+              </label>
+              <select
+                id={`field-${key}`}
+                name={`editedArgs.${key}`}
+                value={String(value ?? '')}
+                onChange={(e) => updateValue(key, e.target.value)}
+                className="mt-1 h-10 w-full rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+              >
+                <option value="">Select…</option>
+                {options.map((opt, idx) => {
+                  const optVal = typeof opt === 'string' ? opt : opt.value
+                  const optText = typeof opt === 'string' ? opt : opt.text
+                  return (
+                    <option key={idx} value={optVal}>
+                      {optText}
+                    </option>
+                  )
+                })}
+              </select>
+            </div>
+          )
+        }
+
+        if (spec.type === 'array') {
+          const arr = Array.isArray(value) ? value : []
+          const itemType = spec.items ?? 'string'
+          return (
+            <div key={key}>
+              <label className="block text-sm font-medium">{label}</label>
+              <div className="mt-2 space-y-2">
+                {arr.map((item, idx) => (
+                  <div key={idx} className="flex gap-2">
+                    {itemType === 'string' ? (
+                      <input
+                        type="text"
+                        name={`editedArgs.${key}[${idx}]`}
+                        value={String(item ?? '')}
+                        onChange={(e) => updateArrayItem(key, idx, e.target.value)}
+                        className="h-10 flex-1 rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                      />
+                    ) : (
+                      <input
+                        type="number"
+                        name={`editedArgs.${key}[${idx}]`}
+                        value={Number(item ?? 0)}
+                        onChange={(e) => {
+                          const val = itemType === 'int' ? parseInt(e.target.value, 10) : parseFloat(e.target.value)
+                          updateArrayItem(key, idx, isNaN(val) ? 0 : val)
+                        }}
+                        step={itemType === 'int' ? 1 : 'any'}
+                        className="h-10 flex-1 rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                      />
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => removeArrayItem(key, idx)}
+                      className="rounded-md border border-zinc-300 px-3 text-sm dark:border-zinc-600"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => addArrayItem(key, itemType)}
+                  disabled={spec.maxItems !== undefined && arr.length >= spec.maxItems}
+                  className="rounded-md bg-zinc-200 px-3 py-1.5 text-sm dark:bg-zinc-700 disabled:opacity-50"
+                >
+                  Add item
+                </button>
+              </div>
+            </div>
+          )
+        }
+
+        return null
+      })}
+
+      {dropdownConfig ? (
+        <div>
+          <label htmlFor="editReason" className="block text-sm font-medium">
+            {dropdownConfig.label ?? 'Edit reason'}
+            {dropdownConfig.required ? ' *' : ''}
+          </label>
+          <select
+            id="editReason"
+            name="editReason"
+            value={editReason}
+            onChange={(e) => setEditReason(e.target.value)}
+            required={dropdownConfig.required}
+            className="mt-1 h-10 w-full rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+          >
+            <option value="">Select…</option>
+            {(dropdownConfig.options ?? DEFAULT_EDIT_REASON_OPTIONS).map((opt, idx) => {
+              const optVal = typeof opt === 'string' ? opt : opt.value
+              const optText = typeof opt === 'string' ? opt : opt.text
+              return (
+                <option key={idx} value={optVal}>
+                  {optText}
+                </option>
+              )
+            })}
+          </select>
+        </div>
+      ) : null}
+
+      {textConfig ? (
+        <div>
+          <label htmlFor="editReasonText" className="block text-sm font-medium">
+            {textConfig.label ?? 'Edit reason details'}
+            {textConfig.required ? ' *' : ''}
+          </label>
+          <textarea
+            id="editReasonText"
+            name="editReasonText"
+            value={editReasonText}
+            onChange={(e) => setEditReasonText(e.target.value)}
+            required={textConfig.required}
+            maxLength={textConfig.maxLength ?? 2000}
+            className="mt-1 min-h-20 w-full rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+          />
+        </div>
+      ) : null}
+
+      <input type="hidden" name="editedArgs" value={JSON.stringify(values)} />
+
+      <details className="rounded-md border border-zinc-200 dark:border-zinc-800" open={showPreview}>
+        <summary
+          className="cursor-pointer select-none px-4 py-2 text-sm font-medium"
+          onClick={(e) => {
+            e.preventDefault()
+            setShowPreview(!showPreview)
+          }}
+        >
+          JSON preview (read-only)
+        </summary>
+        <pre className="overflow-auto border-t border-zinc-200 bg-zinc-50 p-3 text-xs dark:border-zinc-800 dark:bg-zinc-900">
+          {JSON.stringify(mergedArgs, null, 2)}
+        </pre>
+      </details>
+    </div>
+  )
+}

--- a/apps/app/components/work-item-detail.tsx
+++ b/apps/app/components/work-item-detail.tsx
@@ -102,7 +102,7 @@ export async function WorkItemDetail({
   const originRows = originFields(origin)
   const metadata = envelopeMetadata(envelope, origin)
   const allowed = envelope.allowedActions
-  const hasEditableFields = envelope.editableFields && Object.keys(envelope.editableFields).length > 0
+  const hasEditableFields = Boolean(envelope.editableFields && Object.keys(envelope.editableFields).length > 0)
   const showEditControl = allowed.edit && hasEditableFields
   const canAct = canDecide(access) && isOpenApprovalStatus(approval.status)
   const expired = approvalHasExpired(approval)

--- a/apps/app/components/work-item-detail.tsx
+++ b/apps/app/components/work-item-detail.tsx
@@ -7,6 +7,7 @@ import { Badge, PluginBadge, PluginMark } from '@hitly/ui'
 import { decideWorkItem, delegateWorkItem, retryWorkItem } from '@/actions/projects'
 import { AppShell } from '@/components/app-shell'
 import { ContextMarkdown } from '@/components/context-markdown'
+import { EditableFieldsForm } from '@/components/editable-fields-form'
 import { ForceCancelButton } from '@/components/force-cancel-button'
 import { JsonDisclosure } from '@/components/json-disclosure'
 import { RefreshOnFocus, WorkItemDecisionButtons } from '@/components/work-item-client'
@@ -101,6 +102,8 @@ export async function WorkItemDetail({
   const originRows = originFields(origin)
   const metadata = envelopeMetadata(envelope, origin)
   const allowed = envelope.allowedActions
+  const hasEditableFields = envelope.editableFields && Object.keys(envelope.editableFields).length > 0
+  const showEditControl = allowed.edit && hasEditableFields
   const canAct = canDecide(access) && isOpenApprovalStatus(approval.status)
   const expired = approvalHasExpired(approval)
   const canCancel = canDecide(access) && isOpenApprovalStatus(approval.status)
@@ -287,11 +290,11 @@ export async function WorkItemDetail({
       {canAct && !expired ? (
         <form action={decideWorkItem.bind(null, approval.id)} className="mt-6 flex max-w-xl flex-col gap-3">
           <input type="hidden" name="returnTo" value={returnTo} />
-          {allowed.edit ? (
-            <textarea
-              name="editedArgs"
-              placeholder='Edited args JSON, e.g. {"amount": 10}'
-              className="min-h-20 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+          {showEditControl ? (
+            <EditableFieldsForm
+              fields={envelope.editableFields!}
+              originalArgs={envelope.action.args}
+              editReasonConfig={envelope.editReason}
             />
           ) : null}
           {allowed.respond ? (
@@ -301,7 +304,7 @@ export async function WorkItemDetail({
               className="h-10 rounded-md border border-zinc-200 px-3 text-sm dark:border-zinc-700 dark:bg-zinc-900"
             />
           ) : null}
-          <WorkItemDecisionButtons allowed={allowed} />
+          <WorkItemDecisionButtons allowed={{ ...allowed, edit: showEditControl }} />
         </form>
       ) : null}
       {approval.status === 'failed_resume' && canDecide(access) ? (

--- a/apps/app/lib/approvals.ts
+++ b/apps/app/lib/approvals.ts
@@ -392,7 +392,7 @@ export async function decideApproval(args: {
         origin,
         payload: {
           ...args.payload,
-          editedArgs: mergedArgs !== envelope.action.args ? mergedArgs : undefined,
+          editedArgs: editedDelta, // Store only the delta in evidence
         },
         reviewerId: args.actorUserId,
         seq: latest.seq + 1,
@@ -440,7 +440,7 @@ export async function decideApproval(args: {
           },
           {
             ...args.payload,
-            editedArgs: mergedArgs !== envelope.action.args ? mergedArgs : undefined,
+            editedArgs: mergedArgs !== envelope.action.args ? mergedArgs : undefined, // Send merged args to origin
           },
           secured ? { plugin: approval.plugin, ...secured.project.credentials } : undefined,
         )
@@ -617,6 +617,7 @@ const DEFAULT_EDIT_REASON_OPTIONS = [
 /**
  * Validate edit reason fields against the envelope's editReason config.
  * Returns null on success or { error, status } on failure.
+ * When config is omitted, validates with default optional controls.
  */
 export function validateEditReason(args: {
   editReason?: string
@@ -625,10 +626,9 @@ export function validateEditReason(args: {
 }): { error: string; status: 400 } | null {
   const { editReason, editReasonText, editReasonConfig } = args
 
-  if (!editReasonConfig) return null
-
-  const dropdownConfig = editReasonConfig.dropdown === false ? null : editReasonConfig.dropdown ?? {}
-  const textConfig = editReasonConfig.text === false ? null : editReasonConfig.text ?? {}
+  // Default: both controls optional when config is omitted
+  const dropdownConfig = editReasonConfig?.dropdown === false ? null : editReasonConfig?.dropdown ?? {}
+  const textConfig = editReasonConfig?.text === false ? null : editReasonConfig?.text ?? {}
 
   // Validate dropdown
   if (dropdownConfig) {
@@ -770,11 +770,10 @@ export function parseDecisionBody(body: Record<string, unknown>): DecisionPayloa
   if (!isDecision(body.decision)) return null
   const decision = body.decision as Decision
   
-  // Edit requires both editedArgs (delta) and final_sha256
+  // Edit requires editedArgs (we'll compute final_sha256 server-side)
   if (decision === 'edit') {
     const hasEditedArgs = body.editedArgs && typeof body.editedArgs === 'object'
-    const hasFinalSha = typeof body.final_sha256 === 'string' && body.final_sha256.length > 0
-    if (!hasEditedArgs || !hasFinalSha) return null
+    if (!hasEditedArgs) return null
   }
   
   return {

--- a/apps/app/lib/approvals.ts
+++ b/apps/app/lib/approvals.ts
@@ -398,6 +398,7 @@ export async function decideApproval(args: {
         seq: latest.seq + 1,
         prevEventId: latest.prevEventId ?? '',
         prevContentSha256: latest.prevContentSha256 ?? '',
+        mergedArgs, // Pass merged args for final_sha256 computation
       })
       decidedEventId = decidedEvent.event_id
       decidedContentSha256 = decidedEvent.integrity.content_sha256

--- a/apps/app/lib/approvals.ts
+++ b/apps/app/lib/approvals.ts
@@ -10,6 +10,8 @@ import {
   type ChannelType,
   type Decision,
   type DecisionPayload,
+  type EditableFieldSpec,
+  type EditReasonConfig,
   type OriginRef,
   type ResumeResponse,
 } from '@hitly/core'
@@ -335,6 +337,40 @@ export async function decideApproval(args: {
       return { error: `Decision ${args.payload.decision} is not allowed`, status: 400 as const }
     }
 
+    // Fail-closed: if edit is allowed but editableFields is missing or empty, reject
+    if (args.payload.decision === 'edit') {
+      const hasEditableFields = envelope.editableFields && Object.keys(envelope.editableFields).length > 0
+      if (!hasEditableFields) {
+        return { error: 'Edit decision requires editableFields to be defined', status: 400 as const }
+      }
+
+      // Validate edit reason
+      const reasonValidation = validateEditReason({
+        editReason: args.payload.editReason,
+        editReasonText: args.payload.editReasonText,
+        editReasonConfig: envelope.editReason,
+      })
+      if (reasonValidation) {
+        return reasonValidation
+      }
+    }
+
+    // Merge and validate edited args against allowlist
+    let mergedArgs = envelope.action.args
+    let editedDelta: Record<string, unknown> | undefined
+    if (args.payload.decision === 'edit' && args.payload.editedArgs && envelope.editableFields) {
+      const mergeResult = mergeEditableArgs({
+        originalArgs: envelope.action.args,
+        editedArgs: args.payload.editedArgs,
+        editableFields: envelope.editableFields,
+      })
+      if ('error' in mergeResult) {
+        return mergeResult
+      }
+      mergedArgs = mergeResult.mergedArgs
+      editedDelta = mergeResult.editedDelta
+    }
+
     const origin = asOrigin(approval.origin)
     const projectRows = await database
       .select()
@@ -354,7 +390,10 @@ export async function decideApproval(args: {
         approvalId: approval.id,
         envelope,
         origin,
-        payload: args.payload,
+        payload: {
+          ...args.payload,
+          editedArgs: mergedArgs !== envelope.action.args ? mergedArgs : undefined,
+        },
         reviewerId: args.actorUserId,
         seq: latest.seq + 1,
         prevEventId: latest.prevEventId ?? '',
@@ -399,7 +438,10 @@ export async function decideApproval(args: {
               metadata: envelopeMetadata(envelope, origin),
             },
           },
-          args.payload,
+          {
+            ...args.payload,
+            editedArgs: mergedArgs !== envelope.action.args ? mergedArgs : undefined,
+          },
           secured ? { plugin: approval.plugin, ...secured.project.credentials } : undefined,
         )
         if (originResponse) resumeResponse = originResponse
@@ -565,6 +607,165 @@ export async function retryResume(args: { approvalId: string; workspaceId?: stri
   })
 }
 
+const DEFAULT_EDIT_REASON_OPTIONS = [
+  'customer_request',
+  'pricing_correction',
+  'policy_exception',
+  'other',
+]
+
+/**
+ * Validate edit reason fields against the envelope's editReason config.
+ * Returns null on success or { error, status } on failure.
+ */
+export function validateEditReason(args: {
+  editReason?: string
+  editReasonText?: string
+  editReasonConfig?: EditReasonConfig
+}): { error: string; status: 400 } | null {
+  const { editReason, editReasonText, editReasonConfig } = args
+
+  if (!editReasonConfig) return null
+
+  const dropdownConfig = editReasonConfig.dropdown === false ? null : editReasonConfig.dropdown ?? {}
+  const textConfig = editReasonConfig.text === false ? null : editReasonConfig.text ?? {}
+
+  // Validate dropdown
+  if (dropdownConfig) {
+    if (dropdownConfig.required && (!editReason || !editReason.trim())) {
+      return { error: 'Edit reason dropdown is required', status: 400 }
+    }
+    if (editReason) {
+      const options = dropdownConfig.options ?? DEFAULT_EDIT_REASON_OPTIONS
+      const allowedValues = options.map((opt) => (typeof opt === 'string' ? opt : opt.value))
+      if (!allowedValues.includes(editReason)) {
+        return { error: `Edit reason must be one of: ${allowedValues.join(', ')}`, status: 400 }
+      }
+    }
+  }
+
+  // Validate text
+  if (textConfig) {
+    const maxLength = textConfig.maxLength ?? 2000
+    if (textConfig.required && (!editReasonText || !editReasonText.trim())) {
+      return { error: 'Edit reason text is required', status: 400 }
+    }
+    if (editReasonText && editReasonText.length > maxLength) {
+      return { error: `Edit reason text exceeds maximum length ${maxLength}`, status: 400 }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Merge and validate edited args against the envelope's editableFields allowlist.
+ * Returns { mergedArgs, editedDelta } on success or { error, status } on failure.
+ */
+export function mergeEditableArgs(args: {
+  originalArgs: Record<string, unknown>
+  editedArgs: Record<string, unknown>
+  editableFields: Record<string, EditableFieldSpec>
+}): { mergedArgs: Record<string, unknown>; editedDelta: Record<string, unknown> } | { error: string; status: 400 } {
+  const { originalArgs, editedArgs, editableFields } = args
+  const allowedKeys = Object.keys(editableFields)
+
+  const editedDelta: Record<string, unknown> = {}
+  const mergedArgs = { ...originalArgs }
+
+  for (const key of Object.keys(editedArgs)) {
+    if (!allowedKeys.includes(key)) {
+      return { error: `Field "${key}" is not editable`, status: 400 }
+    }
+    const field = editableFields[key]!
+    const value = editedArgs[key]
+
+    if (field.type === 'string') {
+      if (typeof value !== 'string') {
+        return { error: `Field "${key}" must be a string`, status: 400 }
+      }
+      if (field.minLength !== undefined && value.length < field.minLength) {
+        return { error: `Field "${key}" is below min length ${field.minLength}`, status: 400 }
+      }
+      if (field.maxLength !== undefined && value.length > field.maxLength) {
+        return { error: `Field "${key}" exceeds max length ${field.maxLength}`, status: 400 }
+      }
+      editedDelta[key] = value
+      mergedArgs[key] = value
+    } else if (field.type === 'int') {
+      if (typeof value !== 'number' || !Number.isInteger(value) || !Number.isFinite(value)) {
+        return { error: `Field "${key}" must be an integer`, status: 400 }
+      }
+      if (field.min !== undefined && value < field.min) {
+        return { error: `Field "${key}" is below minimum ${field.min}`, status: 400 }
+      }
+      if (field.max !== undefined && value > field.max) {
+        return { error: `Field "${key}" exceeds maximum ${field.max}`, status: 400 }
+      }
+      editedDelta[key] = value
+      mergedArgs[key] = value
+    } else if (field.type === 'float') {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return { error: `Field "${key}" must be a finite number`, status: 400 }
+      }
+      if (field.min !== undefined && value < field.min) {
+        return { error: `Field "${key}" is below minimum ${field.min}`, status: 400 }
+      }
+      if (field.max !== undefined && value > field.max) {
+        return { error: `Field "${key}" exceeds maximum ${field.max}`, status: 400 }
+      }
+      editedDelta[key] = value
+      mergedArgs[key] = value
+    } else if (field.type === 'bool') {
+      if (typeof value !== 'boolean') {
+        return { error: `Field "${key}" must be a boolean`, status: 400 }
+      }
+      editedDelta[key] = value
+      mergedArgs[key] = value
+    } else if (field.type === 'enum') {
+      if (typeof value !== 'string') {
+        return { error: `Field "${key}" must be a string`, status: 400 }
+      }
+      if (!field.options || field.options.length === 0) {
+        return { error: `Field "${key}" has no valid options`, status: 400 }
+      }
+      const allowedValues = field.options.map((opt) =>
+        typeof opt === 'string' ? opt : opt.value
+      )
+      if (!allowedValues.includes(value)) {
+        return { error: `Field "${key}" must be one of: ${allowedValues.join(', ')}`, status: 400 }
+      }
+      editedDelta[key] = value
+      mergedArgs[key] = value
+    } else if (field.type === 'array') {
+      if (!Array.isArray(value)) {
+        return { error: `Field "${key}" must be an array`, status: 400 }
+      }
+      if (field.minItems !== undefined && value.length < field.minItems) {
+        return { error: `Field "${key}" requires at least ${field.minItems} items`, status: 400 }
+      }
+      if (field.maxItems !== undefined && value.length > field.maxItems) {
+        return { error: `Field "${key}" exceeds maximum ${field.maxItems} items`, status: 400 }
+      }
+      for (const item of value) {
+        if (field.items === 'string' && typeof item !== 'string') {
+          return { error: `Field "${key}" must contain only strings`, status: 400 }
+        }
+        if (field.items === 'int' && (typeof item !== 'number' || !Number.isInteger(item) || !Number.isFinite(item))) {
+          return { error: `Field "${key}" must contain only integers`, status: 400 }
+        }
+        if (field.items === 'float' && (typeof item !== 'number' || !Number.isFinite(item))) {
+          return { error: `Field "${key}" must contain only finite numbers`, status: 400 }
+        }
+      }
+      editedDelta[key] = value
+      mergedArgs[key] = value
+    }
+  }
+
+  return { mergedArgs, editedDelta }
+}
+
 export function parseDecisionBody(body: Record<string, unknown>): DecisionPayload | null {
   if (!isDecision(body.decision)) return null
   const decision = body.decision as Decision
@@ -581,6 +782,8 @@ export function parseDecisionBody(body: Record<string, unknown>): DecisionPayloa
     editedArgs:
       body.editedArgs && typeof body.editedArgs === 'object' ? (body.editedArgs as Record<string, unknown>) : undefined,
     response: typeof body.response === 'string' ? body.response : undefined,
+    editReason: typeof body.editReason === 'string' ? body.editReason : undefined,
+    editReasonText: typeof body.editReasonText === 'string' ? body.editReasonText : undefined,
   }
 }
 

--- a/apps/app/lib/editable-fields.test.ts
+++ b/apps/app/lib/editable-fields.test.ts
@@ -363,3 +363,36 @@ test('validateEditReason: omitted config validates with defaults', () => {
   assert.ok(resultTooLong)
   assert.equal(resultTooLong.error, 'Edit reason text exceeds maximum length 2000')
 })
+
+test('mergeEditableArgs: final_sha256 is hash of merged args, not delta', async () => {
+  const { hashActionArgs } = await import('@hitly/core')
+  
+  const originalArgs = { orderId: 'OR-123', amount: 100 }
+  const editedArgs = { amount: 50 }
+  const result = mergeEditableArgs({
+    originalArgs,
+    editedArgs,
+    editableFields: {
+      amount: { type: 'int', min: 1 },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  
+  // Verify delta contains only edited fields
+  assert.deepEqual(result.editedDelta, { amount: 50 })
+  assert.ok(!('orderId' in result.editedDelta))
+  
+  // Verify merged args contain both original and edited
+  assert.deepEqual(result.mergedArgs, { orderId: 'OR-123', amount: 50 })
+  
+  // Verify final_sha256 would hash the merged args, not the delta
+  const hashOfMerged = await hashActionArgs(result.mergedArgs)
+  const hashOfDelta = await hashActionArgs(result.editedDelta)
+  assert.notEqual(hashOfMerged, hashOfDelta)
+  
+  // The evidence final_sha256 should equal hash of merged, not hash of delta
+  // This ensures locked fields (orderId) are included in the integrity check
+  const expectedFinalSha256 = hashOfMerged
+  assert.ok(expectedFinalSha256.length > 0)
+})

--- a/apps/app/lib/editable-fields.test.ts
+++ b/apps/app/lib/editable-fields.test.ts
@@ -1,0 +1,360 @@
+import * as assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mergeEditableArgs, validateEditReason } from './approvals'
+
+test('mergeEditableArgs: basic string field', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { orderId: 'OR-123', amount: 100 },
+    editedArgs: { amount: 50 },
+    editableFields: {
+      amount: { type: 'int', min: 1 },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.deepEqual(result.mergedArgs, { orderId: 'OR-123', amount: 50 })
+  assert.deepEqual(result.editedDelta, { amount: 50 })
+})
+
+test('mergeEditableArgs: rejects extra keys', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { orderId: 'OR-123', amount: 100 },
+    editedArgs: { orderId: 'OR-999', amount: 50 },
+    editableFields: {
+      amount: { type: 'int', min: 1 },
+    },
+  })
+
+  assert.ok('error' in result)
+  assert.equal(result.error, 'Field "orderId" is not editable')
+  assert.equal(result.status, 400)
+})
+
+test('mergeEditableArgs: int field validation', () => {
+  const resultMin = mergeEditableArgs({
+    originalArgs: { amount: 100 },
+    editedArgs: { amount: 0 },
+    editableFields: {
+      amount: { type: 'int', min: 1, max: 500 },
+    },
+  })
+
+  assert.ok('error' in resultMin)
+  assert.equal(resultMin.error, 'Field "amount" is below minimum 1')
+
+  const resultMax = mergeEditableArgs({
+    originalArgs: { amount: 100 },
+    editedArgs: { amount: 600 },
+    editableFields: {
+      amount: { type: 'int', min: 1, max: 500 },
+    },
+  })
+
+  assert.ok('error' in resultMax)
+  assert.equal(resultMax.error, 'Field "amount" exceeds maximum 500')
+
+  const resultNotInt = mergeEditableArgs({
+    originalArgs: { amount: 100 },
+    editedArgs: { amount: 10.5 },
+    editableFields: {
+      amount: { type: 'int', min: 1 },
+    },
+  })
+
+  assert.ok('error' in resultNotInt)
+  assert.equal(resultNotInt.error, 'Field "amount" must be an integer')
+})
+
+test('mergeEditableArgs: float field validation', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { price: 10.5 },
+    editedArgs: { price: 20.75 },
+    editableFields: {
+      price: { type: 'float', min: 0, max: 100 },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.equal(result.mergedArgs.price, 20.75)
+
+  const resultNaN = mergeEditableArgs({
+    originalArgs: { price: 10.5 },
+    editedArgs: { price: NaN },
+    editableFields: {
+      price: { type: 'float' },
+    },
+  })
+
+  assert.ok('error' in resultNaN)
+  assert.equal(resultNaN.error, 'Field "price" must be a finite number')
+})
+
+test('mergeEditableArgs: string field validation', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { note: 'old' },
+    editedArgs: { note: 'new note' },
+    editableFields: {
+      note: { type: 'string', minLength: 3, maxLength: 20 },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.equal(result.mergedArgs.note, 'new note')
+
+  const resultTooShort = mergeEditableArgs({
+    originalArgs: { note: 'old' },
+    editedArgs: { note: 'ab' },
+    editableFields: {
+      note: { type: 'string', minLength: 3 },
+    },
+  })
+
+  assert.ok('error' in resultTooShort)
+  assert.equal(resultTooShort.error, 'Field "note" is below min length 3')
+
+  const resultTooLong = mergeEditableArgs({
+    originalArgs: { note: 'old' },
+    editedArgs: { note: 'this is way too long for the field' },
+    editableFields: {
+      note: { type: 'string', maxLength: 20 },
+    },
+  })
+
+  assert.ok('error' in resultTooLong)
+  assert.equal(resultTooLong.error, 'Field "note" exceeds max length 20')
+})
+
+test('mergeEditableArgs: bool field', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { urgent: false },
+    editedArgs: { urgent: true },
+    editableFields: {
+      urgent: { type: 'bool' },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.equal(result.mergedArgs.urgent, true)
+
+  const resultInvalid = mergeEditableArgs({
+    originalArgs: { urgent: false },
+    editedArgs: { urgent: 'yes' as unknown as boolean },
+    editableFields: {
+      urgent: { type: 'bool' },
+    },
+  })
+
+  assert.ok('error' in resultInvalid)
+  assert.equal(resultInvalid.error, 'Field "urgent" must be a boolean')
+})
+
+test('mergeEditableArgs: enum field with string options', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { status: 'pending' },
+    editedArgs: { status: 'approved' },
+    editableFields: {
+      status: { type: 'enum', options: ['pending', 'approved', 'rejected'] },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.equal(result.mergedArgs.status, 'approved')
+
+  const resultInvalid = mergeEditableArgs({
+    originalArgs: { status: 'pending' },
+    editedArgs: { status: 'unknown' },
+    editableFields: {
+      status: { type: 'enum', options: ['pending', 'approved', 'rejected'] },
+    },
+  })
+
+  assert.ok('error' in resultInvalid)
+  assert.ok(resultInvalid.error.includes('must be one of'))
+})
+
+test('mergeEditableArgs: enum field with object options', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { type: 'full' },
+    editedArgs: { type: 'partial' },
+    editableFields: {
+      type: {
+        type: 'enum',
+        options: [
+          { value: 'full', text: 'Full refund' },
+          { value: 'partial', text: 'Partial refund' },
+        ],
+      },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.equal(result.mergedArgs.type, 'partial')
+})
+
+test('mergeEditableArgs: enum field with empty options', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { type: 'full' },
+    editedArgs: { type: 'partial' },
+    editableFields: {
+      type: { type: 'enum', options: [] },
+    },
+  })
+
+  assert.ok('error' in result)
+  assert.equal(result.error, 'Field "type" has no valid options')
+})
+
+test('mergeEditableArgs: array field with string items', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { tags: ['old'] },
+    editedArgs: { tags: ['new', 'updated'] },
+    editableFields: {
+      tags: { type: 'array', items: 'string', minItems: 1, maxItems: 5 },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.deepEqual(result.mergedArgs.tags, ['new', 'updated'])
+
+  const resultTooFew = mergeEditableArgs({
+    originalArgs: { tags: ['old'] },
+    editedArgs: { tags: [] },
+    editableFields: {
+      tags: { type: 'array', items: 'string', minItems: 1 },
+    },
+  })
+
+  assert.ok('error' in resultTooFew)
+  assert.equal(resultTooFew.error, 'Field "tags" requires at least 1 items')
+
+  const resultTooMany = mergeEditableArgs({
+    originalArgs: { tags: ['old'] },
+    editedArgs: { tags: ['a', 'b', 'c', 'd', 'e', 'f'] },
+    editableFields: {
+      tags: { type: 'array', items: 'string', maxItems: 5 },
+    },
+  })
+
+  assert.ok('error' in resultTooMany)
+  assert.equal(resultTooMany.error, 'Field "tags" exceeds maximum 5 items')
+})
+
+test('mergeEditableArgs: array field with int items', () => {
+  const result = mergeEditableArgs({
+    originalArgs: { quantities: [1, 2] },
+    editedArgs: { quantities: [5, 10, 15] },
+    editableFields: {
+      quantities: { type: 'array', items: 'int' },
+    },
+  })
+
+  assert.ok('mergedArgs' in result)
+  assert.deepEqual(result.mergedArgs.quantities, [5, 10, 15])
+
+  const resultInvalid = mergeEditableArgs({
+    originalArgs: { quantities: [1, 2] },
+    editedArgs: { quantities: [5, 10.5, 15] },
+    editableFields: {
+      quantities: { type: 'array', items: 'int' },
+    },
+  })
+
+  assert.ok('error' in resultInvalid)
+  assert.equal(resultInvalid.error, 'Field "quantities" must contain only integers')
+})
+
+test('validateEditReason: required dropdown', () => {
+  const result = validateEditReason({
+    editReason: undefined,
+    editReasonConfig: {
+      dropdown: { required: true },
+    },
+  })
+
+  assert.ok(result)
+  assert.equal(result.error, 'Edit reason dropdown is required')
+})
+
+test('validateEditReason: dropdown value validation', () => {
+  const result = validateEditReason({
+    editReason: 'invalid_value',
+    editReasonConfig: {
+      dropdown: { options: ['customer_request', 'pricing_correction', 'other'] },
+    },
+  })
+
+  assert.ok(result)
+  assert.ok(result.error.includes('must be one of'))
+})
+
+test('validateEditReason: required text', () => {
+  const result = validateEditReason({
+    editReasonText: '',
+    editReasonConfig: {
+      text: { required: true },
+    },
+  })
+
+  assert.ok(result)
+  assert.equal(result.error, 'Edit reason text is required')
+})
+
+test('validateEditReason: text maxLength', () => {
+  const result = validateEditReason({
+    editReasonText: 'a'.repeat(3000),
+    editReasonConfig: {
+      text: { maxLength: 2000 },
+    },
+  })
+
+  assert.ok(result)
+  assert.equal(result.error, 'Edit reason text exceeds maximum length 2000')
+})
+
+test('validateEditReason: valid with both controls', () => {
+  const result = validateEditReason({
+    editReason: 'customer_request',
+    editReasonText: 'Customer threatened chargeback',
+    editReasonConfig: {
+      dropdown: { required: true },
+      text: { maxLength: 2000 },
+    },
+  })
+
+  assert.equal(result, null)
+})
+
+test('validateEditReason: hidden dropdown', () => {
+  const result = validateEditReason({
+    editReason: undefined,
+    editReasonConfig: {
+      dropdown: false,
+      text: { required: true },
+    },
+  })
+
+  // Should not validate dropdown when hidden
+  assert.ok(result)
+  assert.equal(result.error, 'Edit reason text is required')
+})
+
+test('validateEditReason: default options', () => {
+  const result = validateEditReason({
+    editReason: 'customer_request',
+    editReasonConfig: {
+      dropdown: {},
+    },
+  })
+
+  assert.equal(result, null)
+
+  const resultInvalid = validateEditReason({
+    editReason: 'not_in_defaults',
+    editReasonConfig: {
+      dropdown: {},
+    },
+  })
+
+  assert.ok(resultInvalid)
+  assert.ok(resultInvalid.error.includes('must be one of'))
+})

--- a/apps/app/lib/editable-fields.test.ts
+++ b/apps/app/lib/editable-fields.test.ts
@@ -338,23 +338,28 @@ test('validateEditReason: hidden dropdown', () => {
   assert.equal(result.error, 'Edit reason text is required')
 })
 
-test('validateEditReason: default options', () => {
+test('validateEditReason: omitted config validates with defaults', () => {
+  // Valid with defaults (optional controls)
   const result = validateEditReason({
     editReason: 'customer_request',
-    editReasonConfig: {
-      dropdown: {},
-    },
+    editReasonText: 'Customer requested',
+    editReasonConfig: undefined,
   })
-
   assert.equal(result, null)
 
+  // Invalid: dropdown value not in defaults
   const resultInvalid = validateEditReason({
     editReason: 'not_in_defaults',
-    editReasonConfig: {
-      dropdown: {},
-    },
+    editReasonConfig: undefined,
   })
-
   assert.ok(resultInvalid)
   assert.ok(resultInvalid.error.includes('must be one of'))
+
+  // Invalid: text too long (default maxLength 2000)
+  const resultTooLong = validateEditReason({
+    editReasonText: 'a'.repeat(2001),
+    editReasonConfig: undefined,
+  })
+  assert.ok(resultTooLong)
+  assert.equal(resultTooLong.error, 'Edit reason text exceeds maximum length 2000')
 })

--- a/apps/app/lib/evidence.ts
+++ b/apps/app/lib/evidence.ts
@@ -90,6 +90,7 @@ export async function buildDecidedEvent(args: {
   seq: number
   prevEventId: string
   prevContentSha256: string
+  mergedArgs?: Record<string, unknown>
 }): Promise<EvidenceEvent> {
   const occurredAt = new Date().toISOString()
   const proposedSha256 = await hashActionArgs(args.envelope.action.args)
@@ -103,7 +104,7 @@ export async function buildDecidedEvent(args: {
     args.payload.decision === 'edit' && args.payload.editedArgs
       ? {
           ...actionBase,
-          final_sha256: await hashActionArgs(args.payload.editedArgs),
+          final_sha256: await hashActionArgs(args.mergedArgs ?? args.payload.editedArgs),
           delta: args.payload.editedArgs,
         }
       : {

--- a/apps/app/lib/evidence.ts
+++ b/apps/app/lib/evidence.ts
@@ -143,6 +143,9 @@ export async function buildDecidedEvent(args: {
       reviewer_id: args.reviewerId,
       decision: args.payload.decision,
       decided_at: occurredAt,
+      response: args.payload.response,
+      edit_reason: args.payload.editReason,
+      edit_reason_text: args.payload.editReasonText,
     },
     retention: {
       min_days: 180,

--- a/apps/web/content/docs/envelope.mdx
+++ b/apps/web/content/docs/envelope.mdx
@@ -19,6 +19,27 @@ interface ApprovalEnvelope {
   resumeSchema?: Record<string, unknown>
   expiresAt?: string
 
+  // Typed editable fields (allowlist + validation)
+  editableFields?: Record<string, {
+    type: 'string' | 'int' | 'float' | 'bool' | 'enum' | 'array'
+    label?: string
+    minLength?: number
+    maxLength?: number
+    min?: number
+    max?: number
+    step?: number
+    options?: Array<string | { value: string; text: string }>
+    items?: 'string' | 'int' | 'float'
+    minItems?: number
+    maxItems?: number
+  }>
+
+  // Edit reason capture (not part of action.args)
+  editReason?: {
+    dropdown?: false | { required?: boolean; options?: Array<string | { value: string; text: string }>; label?: string }
+    text?: false | { required?: boolean; maxLength?: number; label?: string }
+  }
+
   // Evidence fields (optional, persisted when present)
   traceId?: string
   spanId?: string
@@ -55,7 +76,131 @@ interface OriginRef {
 
 `resumeHandle` is opaque per plugin (Mastra base URL + run/step ids, Hermes request/task ids, HTTP `resumeUrl` + optional `metadata`, LangGraph thread id, Temporal workflow id). Origin credentials live on the **project**.
 
-HTTP ingest may include `metadata` (a JSON object). It is stored on the envelope and echoed unchanged on the resume POST for both accept and reject, next to `decision` and the HITL<sub><i>y</i></sub> `id`.
+HTTP ingest may include `metadata` (a JSON object). It is stored on the envelope and echoed unchanged on the resume POST for both accept and reject, next to `decision` and the HITLy `id`.
+
+## Typed Editable Fields
+
+When `allowedActions.edit` is true, the origin can declare which fields the reviewer may edit and how they are validated. `editableFields` is a dictionary where each key is an `action.args` field name and the value defines its type and constraints.
+
+**Keys not listed in `editableFields` are locked** and cannot be edited, even if the client sends them. If `allowedActions.edit` is true but `editableFields` is missing or empty, HITLy **fail-closes**: the Edit button is hidden in the UI, and any `edit` decision returns HTTP 400.
+
+### Field Types
+
+- **`string`**: Text input. Supports `minLength`, `maxLength`, `label`.
+- **`int`**: Integer input. Supports `min`, `max`, `label`.
+- **`float`**: Decimal input. Supports `min`, `max`, `step`, `label`.
+- **`bool`**: Checkbox. Supports `label`.
+- **`enum`**: Dropdown picker. Requires `options` (array of strings or `{ value, text }` objects). Empty `options` → 400.
+- **`array`**: Add/remove list of items. Requires `items` (`'string' | 'int' | 'float'`). Supports `minItems`, `maxItems`, `label`.
+
+### Example: Refund with Editable Amount
+
+```ts
+{
+  action: { name: 'send_refund', args: { orderId: 'OR-123', amount: 100 } },
+  allowedActions: { accept: true, reject: true, edit: true },
+  editableFields: {
+    amount: { type: 'int', min: 1, max: 500, label: 'Refund amount' }
+  }
+}
+```
+
+The reviewer sees a form with a single `amount` field (number input with min/max). `orderId` is locked and shown read-only in the args block.
+
+If the reviewer edits `amount` to 50, the decide POST must include:
+
+```json
+{
+  "decision": "edit",
+  "editedArgs": { "amount": 50 },
+  "final_sha256": "<sha256 of merged args>"
+}
+```
+
+HITLy merges locked fields (`orderId`) with the edited fields (`amount`) and validates:
+
+- Extra keys (e.g., `orderId` in `editedArgs` when only `amount` is editable) → HTTP 400
+- Type mismatch (string in `int`, NaN, array of objects) → HTTP 400
+- Out-of-range or invalid values → HTTP 400
+
+The origin receives the **merged args** (`{ orderId: 'OR-123', amount: 50 }`). The evidence `decided` event stores only the **allowlisted delta** in `editedArgs`, and `final_sha256` is the hash of the merged args.
+
+### Enum Options
+
+`enum` options support both shorthand strings and labeled objects:
+
+```ts
+editableFields: {
+  refundType: {
+    type: 'enum',
+    options: ['full', 'partial'],  // value = label
+    label: 'Refund type'
+  },
+  reason: {
+    type: 'enum',
+    options: [
+      { value: 'damaged', text: 'Item damaged' },
+      { value: 'late', text: 'Delivery late' }
+    ],
+    label: 'Reason'
+  }
+}
+```
+
+The UI picker shows `text` (or the string itself). The `editedArgs` POST always contains the `value`.
+
+## Edit Reason
+
+When `allowedActions.edit` is true, the origin can optionally capture **why** the reviewer edited the action. Edit reason is **not** part of `action.args` and is stored separately in the decision payload and evidence.
+
+### Configuration
+
+```ts
+editReason?: {
+  dropdown?: false | { required?: boolean; options?: Array<string | { value: string; text: string }>; label?: string }
+  text?: false | { required?: boolean; maxLength?: number; label?: string }
+}
+```
+
+- **Omit `editReason`**: Both dropdown and text are shown, optional, with default dropdown options.
+- **Dropdown**: Set to `false` to hide, or configure with `required`, custom `options`, and `label`. Default options: `customer_request`, `pricing_correction`, `policy_exception`, `other`.
+- **Text**: Set to `false` to hide, or configure with `required`, `maxLength` (default 2000), and `label`.
+
+### Example
+
+```ts
+{
+  action: { name: 'send_refund', args: { orderId: 'OR-123', amount: 100 } },
+  allowedActions: { accept: true, reject: true, edit: true },
+  editableFields: {
+    amount: { type: 'int', min: 1, label: 'Amount' }
+  },
+  editReason: {
+    dropdown: { required: true, options: ['customer_escalation', 'manager_override', 'other'] },
+    text: { maxLength: 500, label: 'Additional details' }
+  }
+}
+```
+
+The reviewer must select a dropdown reason and may optionally provide text. The decide POST includes:
+
+```json
+{
+  "decision": "edit",
+  "editedArgs": { "amount": 50 },
+  "editReason": "customer_escalation",
+  "editReasonText": "Customer threatened chargeback",
+  "final_sha256": "<sha256 of merged args>"
+}
+```
+
+Validation rules:
+
+- Required dropdown or text field left blank → HTTP 400
+- Dropdown value not in `options` → HTTP 400
+- Text exceeds `maxLength` → HTTP 400
+
+Edit reason is persisted in the `DecisionPayload` and the evidence `decided` event under `oversight.edit_reason` and `oversight.edit_reason_text`. It is **not** merged into `action.args` or included in `final_sha256`.
 
 ## Evidence Fields
 

--- a/examples/mastra/src/mastra/tools/send-refund-tool.ts
+++ b/examples/mastra/src/mastra/tools/send-refund-tool.ts
@@ -92,6 +92,10 @@ export const sendRefundTool = createTool({
           stepId: agent?.toolCallId ?? 'send-refund',
           stepName: 'send-refund',
           action: { name: 'send-refund', args: { orderId, amount } },
+          allowedActions: { accept: true, reject: true, edit: true },
+          editableFields: {
+            amount: { type: 'int', min: 1, label: 'Refund amount' },
+          },
           // Evidence fields for audit trail
           systemId: 'refund-agent-prod',
           inventoryId: 'ai-inv-refund-agent-v2',

--- a/packages/core/src/evidence.ts
+++ b/packages/core/src/evidence.ts
@@ -45,6 +45,9 @@ export interface EvidenceOversight {
   reviewer_id?: string
   decision?: Decision
   decided_at?: string
+  response?: string
+  edit_reason?: string
+  edit_reason_text?: string
 }
 
 export interface EvidenceRetention {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,25 @@ export interface ApprovalAttachment {
   contentType?: string
 }
 
+export interface EditableFieldSpec {
+  type: 'string' | 'int' | 'float' | 'bool' | 'enum' | 'array'
+  label?: string
+  minLength?: number
+  maxLength?: number
+  min?: number
+  max?: number
+  step?: number
+  options?: Array<string | { value: string; text: string }>
+  items?: 'string' | 'int' | 'float'
+  minItems?: number
+  maxItems?: number
+}
+
+export interface EditReasonConfig {
+  dropdown?: false | { required?: boolean; options?: Array<string | { value: string; text: string }>; label?: string }
+  text?: false | { required?: boolean; maxLength?: number; label?: string }
+}
+
 export interface ApprovalEnvelope {
   action: ActionRequest
   allowedActions: AllowedActions
@@ -68,6 +87,10 @@ export interface ApprovalEnvelope {
   attachments?: ApprovalAttachment[]
   resumeSchema?: Record<string, unknown>
   expiresAt?: string
+  /** Allowlist of editable action.args fields with type validation. Key = field name, value = type + rules. */
+  editableFields?: Record<string, EditableFieldSpec>
+  /** Edit reason capture (dropdown and/or text). Not merged into action.args. */
+  editReason?: EditReasonConfig
   /** Evidence fields for audit trail (optional at ingest) */
   traceId?: string
   spanId?: string
@@ -110,6 +133,8 @@ export interface DecisionPayload {
   decision: Decision
   editedArgs?: Record<string, unknown>
   response?: string
+  editReason?: string
+  editReasonText?: string
 }
 
 /** Origin HTTP/result payload stored on the inbox item after resume. */

--- a/packages/plugin-http/src/index.ts
+++ b/packages/plugin-http/src/index.ts
@@ -43,7 +43,7 @@ export const httpPlugin: HitlyPlugin = {
         : undefined
     const editableFields =
       body.editableFields && typeof body.editableFields === 'object'
-        ? (body.editableFields as Record<string, unknown>)
+        ? (body.editableFields as Record<string, Record<string, unknown>>)
         : undefined
     const editReason =
       body.editReason && typeof body.editReason === 'object' ? (body.editReason as Record<string, unknown>) : undefined
@@ -56,8 +56,8 @@ export const httpPlugin: HitlyPlugin = {
       allowedActions: allowedActionsFor(allowedActionsPartial ?? { accept: true, reject: true }),
       contextMarkdown: typeof body.contextMarkdown === 'string' ? body.contextMarkdown : undefined,
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
-      editableFields,
-      editReason,
+      editableFields: editableFields as any,
+      editReason: editReason as any,
       origin: {
         plugin: 'http',
         projectId: String(body.projectId ?? ''),

--- a/packages/plugin-http/src/index.ts
+++ b/packages/plugin-http/src/index.ts
@@ -36,14 +36,28 @@ export const httpPlugin: HitlyPlugin = {
     const args = asRecord(body.args)
     const metadata = asRecord(body.metadata)
     const pageId = optionalString(metadata.pageId) ?? optionalString(args.pageId)
+
+    const allowedActionsPartial =
+      body.allowedActions && typeof body.allowedActions === 'object'
+        ? (body.allowedActions as Record<string, boolean>)
+        : undefined
+    const editableFields =
+      body.editableFields && typeof body.editableFields === 'object'
+        ? (body.editableFields as Record<string, unknown>)
+        : undefined
+    const editReason =
+      body.editReason && typeof body.editReason === 'object' ? (body.editReason as Record<string, unknown>) : undefined
+
     return {
       action: {
         name: String(body.actionName ?? 'http-callback'),
         args,
       },
-      allowedActions: allowedActionsFor({ accept: true, reject: true }),
+      allowedActions: allowedActionsFor(allowedActionsPartial ?? { accept: true, reject: true }),
       contextMarkdown: typeof body.contextMarkdown === 'string' ? body.contextMarkdown : undefined,
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      editableFields,
+      editReason,
       origin: {
         plugin: 'http',
         projectId: String(body.projectId ?? ''),

--- a/packages/plugin-mastra/src/index.ts
+++ b/packages/plugin-mastra/src/index.ts
@@ -43,6 +43,9 @@ export interface MastraIngestPayload {
   toolName?: string
   sensitivity?: string[]
   dataCategories?: string[]
+  allowedActions?: Record<string, boolean>
+  editableFields?: Record<string, unknown>
+  editReason?: Record<string, unknown>
 }
 
 export interface MastraWorkflowResumeHandle {
@@ -217,12 +220,23 @@ export function ingestMastra(raw: unknown): ApprovalEnvelope & { origin: OriginR
   const sensitivity = stringList(body.sensitivity)
   const dataCategories = stringList(body.dataCategories)
 
+  const allowedActionsPartial =
+    body.allowedActions && typeof body.allowedActions === 'object'
+      ? (body.allowedActions as Record<string, boolean>)
+      : undefined
+  const editableFields =
+    body.editableFields && typeof body.editableFields === 'object'
+      ? (body.editableFields as Record<string, unknown>)
+      : undefined
+  const editReason =
+    body.editReason && typeof body.editReason === 'object' ? (body.editReason as Record<string, unknown>) : undefined
+
   return {
     action: {
       name: String(action.name ?? stepId),
       args: asRecord(action.args ?? suspendPayload),
     },
-    allowedActions: allowedActionsFor({
+    allowedActions: allowedActionsFor(allowedActionsPartial ?? {
       accept: true,
       reject: true,
       edit: Boolean(body.resumeSchema),
@@ -235,6 +249,8 @@ export function ingestMastra(raw: unknown): ApprovalEnvelope & { origin: OriginR
     attachments: attachmentList(suspendPayload.attachments) ?? attachmentList(body.attachments),
     resumeSchema: asRecord(body.resumeSchema),
     expiresAt: typeof body.expiresAt === 'string' ? body.expiresAt : undefined,
+    editableFields,
+    editReason,
     traceId,
     spanId,
     agentId: kind === 'agent' ? agentId : undefined,
@@ -385,6 +401,9 @@ export interface HitlyApprovalStepConfig {
   toolName?: string
   sensitivity?: string[]
   dataCategories?: string[]
+  allowedActions?: Record<string, boolean>
+  editableFields?: Record<string, unknown>
+  editReason?: Record<string, unknown>
 }
 
 /**
@@ -437,6 +456,9 @@ export async function notifyHitlyApproval(
       toolName: config.toolName,
       sensitivity: config.sensitivity,
       dataCategories: config.dataCategories,
+      allowedActions: config.allowedActions,
+      editableFields: config.editableFields,
+      editReason: config.editReason,
     } satisfies MastraIngestPayload),
   })
 

--- a/packages/plugin-mastra/src/index.ts
+++ b/packages/plugin-mastra/src/index.ts
@@ -226,7 +226,7 @@ export function ingestMastra(raw: unknown): ApprovalEnvelope & { origin: OriginR
       : undefined
   const editableFields =
     body.editableFields && typeof body.editableFields === 'object'
-      ? (body.editableFields as Record<string, unknown>)
+      ? (body.editableFields as Record<string, Record<string, unknown>>)
       : undefined
   const editReason =
     body.editReason && typeof body.editReason === 'object' ? (body.editReason as Record<string, unknown>) : undefined
@@ -249,8 +249,8 @@ export function ingestMastra(raw: unknown): ApprovalEnvelope & { origin: OriginR
     attachments: attachmentList(suspendPayload.attachments) ?? attachmentList(body.attachments),
     resumeSchema: asRecord(body.resumeSchema),
     expiresAt: typeof body.expiresAt === 'string' ? body.expiresAt : undefined,
-    editableFields,
-    editReason,
+    editableFields: editableFields as any,
+    editReason: editReason as any,
     traceId,
     spanId,
     agentId: kind === 'agent' ? agentId : undefined,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #51

## Summary

Implements typed editable fields with allowlist-based validation. The reviewer sees a form with typed controls (number, text, checkbox, dropdown, array), not a JSON textarea. Locked fields are shown read-only. Edit reason (dropdown + optional text) captures why the edit was made, separate from action args.

## Changes

### Core Types (`@hitly/core`)

- **`editableFields`**: Dictionary where keys are arg names and values define type + validation rules
- **`editReason`**: Optional dropdown and text capture (not merged into args)
- **Field types**: `string`, `int`, `float`, `bool`, `enum`, `array` with validation constraints
- **Enum options**: Support both `["value"]` and `[{ value, text }]` formats
- **Edit reason**: Dropdown defaults to `customer_request`, `pricing_correction`, `policy_exception`, `other`

### Server (`apps/app`)

- **`mergeEditableArgs`**: Production helper validates and merges edits
  - Extra keys → 400
  - Type mismatches → 400
  - Out-of-range values → 400
- **`validateEditReason`**: Validates required fields, options, and maxLength
- **Fail-closed**: If `allowedActions.edit` is true but `editableFields` is missing/empty, Edit is hidden and POST returns 400
- **Evidence**: `editReason` and `editReasonText` stored in `DecisionPayload` and evidence `oversight`, not in `action.args`
- **`final_sha256`**: Hash of merged args only (edit reason not included)

### Web UI (`apps/app`)

- **`EditableFieldsForm`**: Client component generates typed form from `editableFields`
  - Number inputs for `int`/`float` with min/max/step
  - Text inputs for `string` with minLength/maxLength
  - Checkbox for `bool`
  - Select for `enum` with custom options
  - Add/remove list for `array` with minItems/maxItems
- **Edit reason controls**: Dropdown (required/optional) + text field (optional, maxLength default 2000)
- **JSON preview**: Collapsed by default, read-only, shows merged args (not edit reason)
- **Locked fields**: Shown in existing args block, not in the form

### Documentation

- **`envelope.mdx`**: Complete examples of `editableFields` and `editReason` configuration
- **Refund example**: `amount` is editable (`int`, min 1), `orderId` is locked

### Tests

- **18 new tests**: Cover all field types, validation rules, enum formats, array bounds, edit reason validation
- All tests pass

## Accept Bar

✅ Amount editable, orderId locked: form has amount only  
✅ POST `{ editedArgs: { orderId: "x", amount: 1 } }` → 400  
✅ Stored `editedArgs` has no orderId  
✅ `int`, `float`, `array` controls work  
✅ JSON preview optional and not required to submit  
✅ Tests import production merge/validate helper  
✅ Edit reason dropdown + text validated

## PR workflow

After CI is green, this PR is ready for Test's review. Dev will not merge until Test accepts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4fe3130-695a-46a2-87f5-7ec562ceaf93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4fe3130-695a-46a2-87f5-7ec562ceaf93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

