### PR TITLE
Fix Phoenix example link in trace.mdx

### DIFF
--- a/apps/web/content/docs/trace.mdx
+++ b/apps/web/content/docs/trace.mdx
@@ -156,4 +156,4 @@ HITL<sub><i>y</i></sub> does not sample. It exports every approval lifecycle eve
 - [Envelope](/docs/envelope) (evidence fields: `traceId`, `spanId`, `agentId`, `systemId`, etc.)
 - [S3](/docs/s3) (evidence sink with full payloads, integrity hashes, fail-closed on decided)
 - [Evidence HTTP Sink](/docs/envelope#http-sink-configuration) (custom audit log endpoints)
-- [Phoenix Example](/examples/phoenix/README.md)
+- [Phoenix Example](https://github.com/hitly-net/hitly/blob/main/examples/phoenix/README.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #56

## Change

Changed the Phoenix example link in `apps/web/content/docs/trace.mdx` from a relative path (`/examples/phoenix/README.md`) to an absolute GitHub URL (`https://github.com/hitly-net/hitly/blob/main/examples/phoenix/README.md`).

The relative link was resulting in a 404 when rendered on the hitly.net marketing site.

## Testing

- Link now correctly points to the Phoenix example README on GitHub
- No other changes made to the documentation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fd5b78b-e2d7-4205-9cc0-039de1f062c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fd5b78b-e2d7-4205-9cc0-039de1f062c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

