### PR TITLE
Add light/dark/system theme picker

### DIFF
--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @source '../../../packages/ui/src';
+@custom-variant dark (&:where(.dark, .dark *));
 
 .markdown {
   @apply text-sm leading-6 text-zinc-700 dark:text-zinc-300;

--- a/apps/app/app/layout.tsx
+++ b/apps/app/app/layout.tsx
@@ -1,7 +1,10 @@
 import { Geist, Geist_Mono } from 'next/font/google'
+import { cookies } from 'next/headers'
 import type { ReactNode } from 'react'
 import './globals.css'
 import { FaviconUpdater } from '@/components/favicon-updater'
+import { ThemeSync } from '@/components/theme-picker'
+import { parseTheme, THEME_COOKIE } from '@/lib/theme'
 
 const geist = Geist({ subsets: ['latin'], variable: '--font-sans' })
 const geistMono = Geist_Mono({ subsets: ['latin'], variable: '--font-mono' })
@@ -11,10 +14,16 @@ export const metadata = {
   description: 'HITLy — approval inbox for agent work',
 }
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const theme = parseTheme((await cookies()).get(THEME_COOKIE)?.value)
+  const htmlClass = [geist.variable, geistMono.variable, theme === 'dark' ? 'dark' : '']
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
+    <html lang="en" className={htmlClass} suppressHydrationWarning>
       <body className="h-dvh overflow-hidden bg-zinc-50 font-sans text-zinc-950 antialiased dark:bg-zinc-950 dark:text-zinc-50">
+        <ThemeSync />
         <FaviconUpdater />
         {children}
       </body>

--- a/apps/app/app/settings/profile/page.tsx
+++ b/apps/app/app/settings/profile/page.tsx
@@ -1,4 +1,5 @@
 import { AppShell } from '@/components/app-shell'
+import { ThemePicker } from '@/components/theme-picker'
 import { getAppContext } from '@/lib/context'
 
 export const metadata = { title: 'Profile' }
@@ -19,6 +20,11 @@ export default async function ProfilePage() {
           <br />
           {user.email}
         </p>
+      </div>
+      <h2 className="mt-10 text-lg font-semibold">Theme</h2>
+      <p className="mt-1 text-sm text-zinc-500">Saved in this browser. System follows your OS appearance.</p>
+      <div className="mt-3">
+        <ThemePicker />
       </div>
     </AppShell>
   )

--- a/apps/app/components/app-toolbar.tsx
+++ b/apps/app/components/app-toolbar.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { ChevronLeft } from 'lucide-react'
 import { switchWorkspace } from '@/actions/workspace'
-import { SignOutButton } from '@/components/sign-out-button'
+import { UserMenu } from '@/components/user-menu'
 import {
   toolbarBackHref,
   toolbarPage,
@@ -80,9 +80,8 @@ export function AppToolbar({
           </option>
         ))}
       </select>
-      <div className="ml-auto flex items-center gap-3 text-sm">
-        <Link href="/settings/profile">{userName}</Link>
-        <SignOutButton />
+      <div className="ml-auto">
+        <UserMenu userName={userName} />
       </div>
     </header>
   )

--- a/apps/app/components/sign-out-button.tsx
+++ b/apps/app/components/sign-out-button.tsx
@@ -2,12 +2,12 @@
 
 import { useRouter } from 'next/navigation'
 
-export function SignOutButton() {
+export function SignOutButton({ className }: { className?: string }) {
   const router = useRouter()
   return (
     <button
       type="button"
-      className="text-sm text-zinc-500 hover:text-zinc-900"
+      className={className ?? 'text-sm text-zinc-500 hover:text-zinc-900'}
       onClick={async () => {
         await fetch('/api/auth/sign-out', { method: 'POST' })
         router.push('/login')

--- a/apps/app/components/theme-picker.tsx
+++ b/apps/app/components/theme-picker.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { Monitor, Moon, Sun } from 'lucide-react'
+import {
+  applyTheme,
+  parseTheme,
+  readThemeCookie,
+  writeThemeCookie,
+  type Theme,
+} from '@/lib/theme'
+
+const OPTIONS: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+]
+
+const themeStore = {
+  listeners: new Set<() => void>(),
+
+  getSnapshot() {
+    return readThemeCookie()
+  },
+
+  subscribe(callback: () => void) {
+    themeStore.listeners.add(callback)
+    return () => themeStore.listeners.delete(callback)
+  },
+
+  notify() {
+    themeStore.listeners.forEach((listener) => listener())
+  },
+
+  set(value: Theme) {
+    writeThemeCookie(value)
+    applyTheme(value)
+    themeStore.notify()
+  },
+}
+
+export function ThemeSync() {
+  const theme = useSyncExternalStore(themeStore.subscribe, themeStore.getSnapshot, () => 'system' as Theme)
+
+  useEffect(() => {
+    applyTheme(theme)
+    if (theme !== 'system') return
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => applyTheme('system')
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
+  }, [theme])
+
+  return null
+}
+
+export function ThemePicker({ compact = false }: { compact?: boolean }) {
+  const theme = useSyncExternalStore(themeStore.subscribe, themeStore.getSnapshot, () => 'system' as Theme)
+
+  const select = useCallback((value: string) => {
+    themeStore.set(parseTheme(value))
+  }, [])
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Theme"
+      className={compact ? 'grid grid-cols-3 gap-1' : 'flex max-w-md gap-1 rounded-md border border-zinc-200 p-1 dark:border-zinc-700'}
+    >
+      {OPTIONS.map((option) => {
+        const Icon = option.icon
+        const selected = theme === option.value
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => select(option.value)}
+            className={
+              selected
+                ? 'inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-zinc-900 px-2 text-xs font-medium text-white dark:bg-zinc-100 dark:text-zinc-900'
+                : 'inline-flex h-8 items-center justify-center gap-1.5 rounded-md px-2 text-xs text-zinc-600 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-900'
+            }
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/app/components/user-menu.tsx
+++ b/apps/app/components/user-menu.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useId, useRef, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { SignOutButton } from '@/components/sign-out-button'
+import { ThemePicker } from '@/components/theme-picker'
+
+export function UserMenu({ userName }: { userName: string }) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(event: PointerEvent) {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setOpen(false)
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-900"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-controls={menuId}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {userName}
+        <ChevronDown className="h-3.5 w-3.5 text-zinc-500" />
+      </button>
+      {open ? (
+        <div
+          id={menuId}
+          role="menu"
+          className="absolute right-0 z-20 mt-1 w-56 rounded-md border border-zinc-200 bg-white p-2 shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+        >
+          <Link
+            href="/settings/profile"
+            role="menuitem"
+            className="block rounded-md px-2 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-900"
+            onClick={() => setOpen(false)}
+          >
+            Profile
+          </Link>
+          <p className="mt-2 px-2 text-xs font-medium text-zinc-500">Theme</p>
+          <div className="mt-1 px-1">
+            <ThemePicker compact />
+          </div>
+          <div className="mt-2 border-t border-zinc-200 pt-2 dark:border-zinc-800">
+            <SignOutButton className="block w-full rounded-md px-2 py-1.5 text-left text-sm text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-900 dark:hover:text-zinc-100" />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/app/lib/theme.ts
+++ b/apps/app/lib/theme.ts
@@ -1,0 +1,26 @@
+export const THEME_COOKIE = 'hitly-theme'
+
+export const THEMES = ['light', 'dark', 'system'] as const
+
+export type Theme = (typeof THEMES)[number]
+
+export function parseTheme(value: string | null | undefined): Theme {
+  return value === 'light' || value === 'dark' ? value : 'system'
+}
+
+export function applyTheme(theme: Theme) {
+  const dark =
+    theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  document.documentElement.classList.toggle('dark', dark)
+  document.documentElement.style.colorScheme = dark ? 'dark' : 'light'
+}
+
+export function readThemeCookie() {
+  if (typeof document === 'undefined') return 'system' as const
+  const match = document.cookie.split('; ').find((part) => part.startsWith(`${THEME_COOKIE}=`))
+  return parseTheme(match?.slice(THEME_COOKIE.length + 1))
+}
+
+export function writeThemeCookie(theme: Theme) {
+  document.cookie = `${THEME_COOKIE}=${theme}; path=/; max-age=31536000; samesite=lax`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port the theme picker feature from PR #50 onto current main. This adds a light/dark/system theme picker in the toolbar user menu and Profile settings, using a cookie + class-based `dark` variant.

Theme half of #50, rebased onto main. Edit-decision half already shipped in #53. Supercedes the conflicted #50.

## Changes

- **New Components:**
  - `theme-picker.tsx` — ThemePicker component with light/dark/system options and ThemeSync for client-side management
  - `user-menu.tsx` — UserMenu component with theme picker dropdown
  - `theme.ts` — Theme library with cookie-based persistence

- **Modified Files:**
  - `app-toolbar.tsx` — Replace profile link + sign-out button with UserMenu
  - `layout.tsx` — Add ThemeSync and apply theme class based on cookie
  - `sign-out-button.tsx` — Add className prop for flexible styling
  - `globals.css` — Add dark mode custom variant
  - `settings/profile/page.tsx` — Add theme section

## Behavior

- Light / Dark / System options in toolbar user menu AND Profile settings
- Theme choice persists via cookie across reloads
- System option follows OS appearance preference
- No layout `<script>` tags (avoids "script tag while rendering React component" warnings)

## Test Plan

- [ ] Open the user menu → switch Light / Dark / System; reload and confirm the choice sticks
- [ ] Confirm Profile also shows the theme control
- [ ] Confirm no "script tag while rendering React component" overlay on load
- [ ] Verify dark mode styles apply correctly throughout the app
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d64bef8-fa5f-49a3-9ffd-4971212e28fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d64bef8-fa5f-49a3-9ffd-4971212e28fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

