### PR TITLE
Add support for external URLs with optional labels

### DIFF
--- a/apps/app/components/context-markdown.tsx
+++ b/apps/app/components/context-markdown.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import type { ApprovalAttachment } from '@hitly/core'
+import { normalizeExternalLinks, type ApprovalAttachment, type ExternalLink } from '@hitly/core'
 import type { Components } from 'react-markdown'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 const components: Components = {
   a: ({ href, children }) => (
-    <a href={href} target="_blank" rel="noreferrer">
+    <a href={href} target="_blank" rel="noopener noreferrer">
       {children}
     </a>
   ),
@@ -19,13 +19,13 @@ export function ContextMarkdown({
   attachments,
 }: {
   value?: string
-  externalUrls?: string[]
+  externalUrls?: ExternalLink[]
   attachments?: ApprovalAttachment[]
 }) {
   const markdown = value?.trim()
-  const urls = externalUrls?.filter((url) => url.trim()) ?? []
+  const links = normalizeExternalLinks(externalUrls)
   const files = attachments?.filter((file) => file.name.trim()) ?? []
-  const empty = !markdown && urls.length === 0 && files.length === 0
+  const empty = !markdown && links.length === 0 && files.length === 0
 
   return (
     <section className="mt-6 max-w-2xl rounded-md border border-zinc-200 dark:border-zinc-800">
@@ -39,14 +39,14 @@ export function ContextMarkdown({
             </ReactMarkdown>
           </div>
         ) : null}
-        {urls.length > 0 ? (
+        {links.length > 0 ? (
           <div className={markdown ? 'mt-4' : undefined}>
             <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Links</h3>
             <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
-              {urls.map((url) => (
-                <li key={url}>
-                  <a href={url} target="_blank" rel="noreferrer" className="break-all underline">
-                    {url}
+              {links.map((link) => (
+                <li key={link.url}>
+                  <a href={link.url} target="_blank" rel="noopener noreferrer" className="break-all underline">
+                    {link.label || link.url}
                   </a>
                 </li>
               ))}
@@ -54,14 +54,14 @@ export function ContextMarkdown({
           </div>
         ) : null}
         {files.length > 0 ? (
-          <div className={markdown || urls.length > 0 ? 'mt-4' : undefined}>
+          <div className={markdown || links.length > 0 ? 'mt-4' : undefined}>
             <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Attachments</h3>
             <p className="mt-1 text-xs text-zinc-500">File preview is not implemented yet.</p>
             <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
               {files.map((file) => (
                 <li key={`${file.name}:${file.url ?? ''}`}>
                   {file.url ? (
-                    <a href={file.url} target="_blank" rel="noreferrer" className="underline">
+                    <a href={file.url} target="_blank" rel="noopener noreferrer" className="underline">
                       {file.name}
                     </a>
                   ) : (

--- a/apps/app/lib/evidence-urls.test.ts
+++ b/apps/app/lib/evidence-urls.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for externalUrls in evidence events.
+ * Verifies URLs are included in evidence and hashed correctly.
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { buildRequestedEvent, buildDecidedEvent, buildResumedEvent } from './evidence'
+import { hashEvidenceContent } from '@hitly/core'
+import type { ApprovalEnvelope, OriginRef, DecisionPayload } from '@hitly/core'
+
+test('buildRequestedEvent includes externalUrls from envelope', async () => {
+  const envelope: ApprovalEnvelope = {
+    action: { name: 'test-action', args: { amount: 100 } },
+    allowedActions: { accept: true, reject: true, edit: false, respond: false, ignore: false, cancel: false },
+    externalUrls: [
+      { url: 'https://example.com/order/123', label: 'Order #123' },
+      { url: 'https://example.com/ticket/456' },
+    ],
+  }
+
+  const origin: OriginRef = {
+    plugin: 'http',
+    projectId: 'proj-123',
+    runId: 'run-456',
+    resumeHandle: {},
+  }
+
+  const event = await buildRequestedEvent({
+    approvalId: 'apr-789',
+    envelope,
+    origin,
+    seq: 1,
+  })
+
+  assert.ok(event.externalUrls)
+  assert.equal(event.externalUrls.length, 2)
+  assert.deepEqual(event.externalUrls[0], { url: 'https://example.com/order/123', label: 'Order #123' })
+  assert.deepEqual(event.externalUrls[1], { url: 'https://example.com/ticket/456' })
+})
+
+test('buildRequestedEvent omits externalUrls when not in envelope', async () => {
+  const envelope: ApprovalEnvelope = {
+    action: { name: 'test-action', args: { amount: 100 } },
+    allowedActions: { accept: true, reject: true, edit: false, respond: false, ignore: false, cancel: false },
+  }
+
+  const origin: OriginRef = {
+    plugin: 'http',
+    projectId: 'proj-123',
+    runId: 'run-456',
+    resumeHandle: {},
+  }
+
+  const event = await buildRequestedEvent({
+    approvalId: 'apr-789',
+    envelope,
+    origin,
+    seq: 1,
+  })
+
+  assert.equal(event.externalUrls, undefined)
+})
+
+test('buildDecidedEvent includes externalUrls from envelope', async () => {
+  const envelope: ApprovalEnvelope = {
+    action: { name: 'test-action', args: { amount: 100 } },
+    allowedActions: { accept: true, reject: true, edit: false, respond: false, ignore: false, cancel: false },
+    externalUrls: [{ url: 'https://example.com/order/123', label: 'Order #123' }],
+  }
+
+  const origin: OriginRef = {
+    plugin: 'http',
+    projectId: 'proj-123',
+    runId: 'run-456',
+    resumeHandle: {},
+  }
+
+  const payload: DecisionPayload = {
+    decision: 'accept',
+  }
+
+  const event = await buildDecidedEvent({
+    approvalId: 'apr-789',
+    envelope,
+    origin,
+    payload,
+    reviewerId: 'user-123',
+    seq: 2,
+    prevEventId: 'evt-001',
+    prevContentSha256: 'abcd1234',
+  })
+
+  assert.ok(event.externalUrls)
+  assert.equal(event.externalUrls.length, 1)
+  assert.deepEqual(event.externalUrls[0], { url: 'https://example.com/order/123', label: 'Order #123' })
+})
+
+test('buildResumedEvent includes externalUrls from envelope', async () => {
+  const envelope: ApprovalEnvelope = {
+    action: { name: 'test-action', args: { amount: 100 } },
+    allowedActions: { accept: true, reject: true, edit: false, respond: false, ignore: false, cancel: false },
+    externalUrls: [{ url: 'https://example.com/order/123' }],
+  }
+
+  const origin: OriginRef = {
+    plugin: 'http',
+    projectId: 'proj-123',
+    runId: 'run-456',
+    resumeHandle: {},
+  }
+
+  const event = await buildResumedEvent({
+    approvalId: 'apr-789',
+    envelope,
+    origin,
+    seq: 3,
+    prevEventId: 'evt-002',
+    prevContentSha256: 'abcd5678',
+    success: true,
+  })
+
+  assert.ok(event.externalUrls)
+  assert.equal(event.externalUrls.length, 1)
+  assert.deepEqual(event.externalUrls[0], { url: 'https://example.com/order/123' })
+})
+
+test('externalUrls are included in evidence hash via hashEvidenceContent', async () => {
+  const envelope: ApprovalEnvelope = {
+    action: { name: 'test-action', args: { amount: 100 } },
+    allowedActions: { accept: true, reject: true, edit: false, respond: false, ignore: false, cancel: false },
+    externalUrls: [{ url: 'https://example.com/order/123', label: 'Order #123' }],
+  }
+
+  const origin: OriginRef = {
+    plugin: 'http',
+    projectId: 'proj-123',
+    runId: 'run-456',
+    resumeHandle: {},
+  }
+
+  const event1 = await buildRequestedEvent({
+    approvalId: 'apr-789',
+    envelope,
+    origin,
+    seq: 1,
+  })
+
+  const envelopeNoUrls: ApprovalEnvelope = {
+    action: { name: 'test-action', args: { amount: 100 } },
+    allowedActions: { accept: true, reject: true, edit: false, respond: false, ignore: false, cancel: false },
+  }
+
+  const event2 = await buildRequestedEvent({
+    approvalId: 'apr-789',
+    envelope: envelopeNoUrls,
+    origin,
+    seq: 1,
+  })
+
+  // Events with different externalUrls should have different hashes
+  assert.notEqual(event1.integrity.content_sha256, event2.integrity.content_sha256)
+
+  // Verify the hash includes externalUrls by computing it manually
+  const recomputedHash = await hashEvidenceContent(event1)
+  assert.equal(event1.integrity.content_sha256, recomputedHash)
+})
+
+test('empty externalUrls array is handled correctly', async () => {
+  const envelope: ApprovalEnvelope = {
+    action: { name: 'test-action', args: { amount: 100 } },
+    allowedActions: { accept: true, reject: true, edit: false, respond: false, ignore: false, cancel: false },
+    externalUrls: [],
+  }
+
+  const origin: OriginRef = {
+    plugin: 'http',
+    projectId: 'proj-123',
+    runId: 'run-456',
+    resumeHandle: {},
+  }
+
+  const event = await buildRequestedEvent({
+    approvalId: 'apr-789',
+    envelope,
+    origin,
+    seq: 1,
+  })
+
+  assert.deepEqual(event.externalUrls, [])
+})

--- a/apps/app/lib/evidence.ts
+++ b/apps/app/lib/evidence.ts
@@ -75,6 +75,7 @@ export async function buildRequestedEvent(args: {
     toolName: args.origin.toolName ?? args.envelope.toolName,
     sensitivity: args.envelope.sensitivity,
     dataCategories: args.envelope.dataCategories,
+    externalUrls: args.envelope.externalUrls,
   }
 
   event.integrity.content_sha256 = await hashEvidenceContent(event)
@@ -161,6 +162,7 @@ export async function buildDecidedEvent(args: {
     toolName: args.origin.toolName ?? args.envelope.toolName,
     sensitivity: args.envelope.sensitivity,
     dataCategories: args.envelope.dataCategories,
+    externalUrls: args.envelope.externalUrls,
   }
 
   event.integrity.content_sha256 = await hashEvidenceContent(event)
@@ -235,6 +237,7 @@ export async function buildResumedEvent(args: {
     toolName: args.origin.toolName ?? args.envelope.toolName,
     sensitivity: args.envelope.sensitivity,
     dataCategories: args.envelope.dataCategories,
+    externalUrls: args.envelope.externalUrls,
   }
 
   event.integrity.content_sha256 = await hashEvidenceContent(event)

--- a/apps/app/lib/external-links.test.ts
+++ b/apps/app/lib/external-links.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for externalUrls with optional labels.
+ * Run with: yarn test
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { normalizeExternalLinks, type ExternalLink } from '@hitly/core'
+import { httpPlugin } from '@hitly/plugin-http'
+import { mastraPlugin } from '@hitly/plugin-mastra'
+
+test('normalizeExternalLinks handles string arrays', () => {
+  const input = ['https://example.com/order/123', 'https://example.com/ticket/456']
+  const result = normalizeExternalLinks(input)
+  assert.deepEqual(result, [
+    { url: 'https://example.com/order/123' },
+    { url: 'https://example.com/ticket/456' },
+  ])
+})
+
+test('normalizeExternalLinks handles ExternalLink objects', () => {
+  const input: ExternalLink[] = [
+    { url: 'https://example.com/order/123', label: 'Order #123' },
+    { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
+  ]
+  const result = normalizeExternalLinks(input)
+  assert.deepEqual(result, [
+    { url: 'https://example.com/order/123', label: 'Order #123' },
+    { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
+  ])
+})
+
+test('normalizeExternalLinks handles mixed arrays', () => {
+  const input: Array<string | ExternalLink> = [
+    'https://example.com/order/123',
+    { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
+    { url: 'https://example.com/policy/789' },
+  ]
+  const result = normalizeExternalLinks(input as any)
+  assert.deepEqual(result, [
+    { url: 'https://example.com/order/123' },
+    { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
+    { url: 'https://example.com/policy/789' },
+  ])
+})
+
+test('normalizeExternalLinks filters empty URLs and trims', () => {
+  const input: Array<string | ExternalLink> = [
+    '  https://example.com/order/123  ',
+    { url: '  https://example.com/ticket/456  ', label: '  Support Ticket  ' },
+    '',
+    { url: '', label: 'Empty URL' },
+    { url: '   ', label: 'Whitespace URL' },
+  ]
+  const result = normalizeExternalLinks(input as any)
+  assert.deepEqual(result, [
+    { url: 'https://example.com/order/123' },
+    { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
+  ])
+})
+
+test('normalizeExternalLinks handles undefined and empty arrays', () => {
+  assert.deepEqual(normalizeExternalLinks(undefined), [])
+  assert.deepEqual(normalizeExternalLinks([]), [])
+})
+
+test('HTTP plugin ingest accepts externalUrls with labels', () => {
+  const body = {
+    resumeUrl: 'https://example.com/resume',
+    runId: 'run-123',
+    projectId: 'proj-456',
+    actionName: 'test-action',
+    args: { amount: 100 },
+    externalUrls: [
+      'https://example.com/order/123',
+      { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
+    ],
+  }
+
+  const result = httpPlugin.ingest(body)
+  assert.ok(result.externalUrls)
+  assert.equal(result.externalUrls.length, 2)
+  assert.deepEqual(result.externalUrls[0], { url: 'https://example.com/order/123' })
+  assert.deepEqual(result.externalUrls[1], { url: 'https://example.com/ticket/456', label: 'Support Ticket' })
+})
+
+test('Mastra plugin ingest accepts externalUrls with labels in suspendPayload', () => {
+  const body = {
+    plugin: 'mastra' as const,
+    projectId: 'proj-456',
+    runId: 'run-123',
+    agentId: 'test-agent',
+    stepId: 'step-1',
+    action: { name: 'test-action', args: { amount: 100 } },
+    suspendPayload: {
+      reason: 'Test reason',
+      externalUrls: [
+        'https://example.com/order/123',
+        { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
+      ],
+    },
+    mastraBaseUrl: 'http://localhost:4111',
+  }
+
+  const result = mastraPlugin.ingest(body)
+  assert.ok(result.externalUrls)
+  assert.equal(result.externalUrls.length, 2)
+  assert.deepEqual(result.externalUrls[0], { url: 'https://example.com/order/123' })
+  assert.deepEqual(result.externalUrls[1], { url: 'https://example.com/ticket/456', label: 'Support Ticket' })
+})
+
+test('Mastra plugin ingest accepts externalUrls with labels in body', () => {
+  const body = {
+    plugin: 'mastra' as const,
+    projectId: 'proj-456',
+    runId: 'run-123',
+    agentId: 'test-agent',
+    stepId: 'step-1',
+    action: { name: 'test-action', args: { amount: 100 } },
+    suspendPayload: {
+      reason: 'Test reason',
+    },
+    externalUrls: [
+      { url: 'https://example.com/policy/789', label: 'Refund Policy' },
+    ],
+    mastraBaseUrl: 'http://localhost:4111',
+  }
+
+  const result = mastraPlugin.ingest(body)
+  assert.ok(result.externalUrls)
+  assert.equal(result.externalUrls.length, 1)
+  assert.deepEqual(result.externalUrls[0], { url: 'https://example.com/policy/789', label: 'Refund Policy' })
+})

--- a/apps/app/lib/external-links.test.ts
+++ b/apps/app/lib/external-links.test.ts
@@ -36,7 +36,8 @@ test('normalizeExternalLinks handles mixed arrays', () => {
     { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
     { url: 'https://example.com/policy/789' },
   ]
-  const result = normalizeExternalLinks(input as any)
+  // Type cast needed because normalizeExternalLinks expects homogeneous arrays at the API boundary
+  const result = normalizeExternalLinks(input as unknown as string[] | ExternalLink[])
   assert.deepEqual(result, [
     { url: 'https://example.com/order/123' },
     { url: 'https://example.com/ticket/456', label: 'Support Ticket' },
@@ -52,7 +53,8 @@ test('normalizeExternalLinks filters empty URLs and trims', () => {
     { url: '', label: 'Empty URL' },
     { url: '   ', label: 'Whitespace URL' },
   ]
-  const result = normalizeExternalLinks(input as any)
+  // Type cast needed because normalizeExternalLinks expects homogeneous arrays at the API boundary
+  const result = normalizeExternalLinks(input as unknown as string[] | ExternalLink[])
   assert.deepEqual(result, [
     { url: 'https://example.com/order/123' },
     { url: 'https://example.com/ticket/456', label: 'Support Ticket' },

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -11,7 +11,7 @@
     "start": "next start --port 3001",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test actions/projects.test.ts lib/approvals.spine.test.ts lib/evidence-sink.test.ts lib/otel-trace.test.ts"
+    "test": "tsx --test actions/projects.test.ts lib/approvals.spine.test.ts lib/evidence-sink.test.ts lib/otel-trace.test.ts lib/external-links.test.ts lib/evidence-urls.test.ts"
   },
   "dependencies": {
     "@hitly/cloud": "*",

--- a/apps/mobile/src/components/detail/ContextMarkdown.tsx
+++ b/apps/mobile/src/components/detail/ContextMarkdown.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react'
 import { Linking, Pressable, Text, View, StyleSheet } from 'react-native'
 import { lexer, type Token, type Tokens } from 'marked'
-import type { ApprovalAttachment } from '@hitly/core'
+import { normalizeExternalLinks, type ApprovalAttachment, type ExternalLink } from '@hitly/core'
 import { colors } from '../../theme'
 
 function openUrl(url?: string) {
@@ -163,13 +163,13 @@ export function ContextMarkdown({
   attachments,
 }: {
   value?: string
-  externalUrls?: string[]
+  externalUrls?: ExternalLink[]
   attachments?: ApprovalAttachment[]
 }) {
   const markdown = value?.trim()
-  const urls = externalUrls?.filter((url) => url.trim()) ?? []
+  const links = normalizeExternalLinks(externalUrls)
   const files = attachments?.filter((file) => file.name.trim()) ?? []
-  const empty = !markdown && urls.length === 0 && files.length === 0
+  const empty = !markdown && links.length === 0 && files.length === 0
   let body: ReactNode = null
   if (markdown) {
     try {
@@ -184,12 +184,12 @@ export function ContextMarkdown({
       <Text style={styles.cardTitle}>Context</Text>
       {empty ? <Text style={styles.muted}>No context provided.</Text> : null}
       {body}
-      {urls.length > 0 ? (
+      {links.length > 0 ? (
         <View style={styles.meta}>
           <Text style={styles.metaTitle}>Links</Text>
-          {urls.map((url) => (
-            <Pressable key={url} onPress={() => openUrl(url)}>
-              <Text style={styles.link}>{url}</Text>
+          {links.map((link) => (
+            <Pressable key={link.url} onPress={() => openUrl(link.url)}>
+              <Text style={styles.link}>{link.label || link.url}</Text>
             </Pressable>
           ))}
         </View>

--- a/apps/web/content/docs/envelope.mdx
+++ b/apps/web/content/docs/envelope.mdx
@@ -14,7 +14,7 @@ interface ApprovalEnvelope {
   allowedActions: Record<Decision, boolean>
   contextMarkdown?: string
   metadata?: Record<string, unknown>
-  externalUrls?: string[]
+  externalUrls?: { url: string; label?: string }[]
   attachments?: { name: string; url?: string; contentType?: string }[]
   resumeSchema?: Record<string, unknown>
   expiresAt?: string
@@ -258,6 +258,67 @@ await notifyHitlyApproval(
 ```
 
 Evidence events are written to the configured HTTP sink (see [Evidence Storage](#evidence-storage) below) as `hitly.evidence.v1` JSON.
+
+## External URLs (Decision Context)
+
+The `externalUrls` field provides reviewers with by-reference links to external decision context: order pages, support tickets, policies, customer profiles, and other resources that should inform the decision. HITLy displays these links in the work item detail but **does not fetch or proxy** the remote content.
+
+### Format
+
+`externalUrls` accepts either a simple string array (legacy) or an array of objects with optional labels:
+
+```ts
+// Simple URLs (backward compatible)
+externalUrls: [
+  'https://example.com/orders/OR-123',
+  'https://example.com/tickets/TK-456'
+]
+
+// With labels (recommended)
+externalUrls: [
+  { url: 'https://example.com/orders/OR-123', label: 'Order #123' },
+  { url: 'https://example.com/tickets/TK-456', label: 'Support Ticket' },
+  { url: 'https://example.com/policies/refund-policy' }  // label is optional
+]
+```
+
+Reviewers see labeled links in the work item detail. Clicking a link opens it in a new tab (`target="_blank" rel="noopener noreferrer"`).
+
+### Evidence
+
+Evidence events hash the **URL list and labels** (by-reference metadata only), not the remote page bytes. The `decided` event includes the same `externalUrls` array that was present at ingest. HITLy does not fetch, store, or verify the remote content—it is the integrator's responsibility to ensure links remain accessible for the evidence retention period.
+
+### Example: Mastra with External URLs
+
+```ts
+import { notifyHitlyApproval } from '@hitly/plugin-mastra'
+
+await notifyHitlyApproval(
+  {
+    // ... config fields omitted for brevity
+    action: { name: 'send_refund', args: { orderId, amount } },
+  },
+  {
+    runId: String(runId),
+    suspendPayload: {
+      reason: `Refund of ${amount} for ${orderId}`,
+      externalUrls: [
+        { url: `https://shop.example.com/orders/${orderId}`, label: `Order ${orderId}` },
+        { url: 'https://shop.example.com/policies/refund', label: 'Refund Policy' },
+        `https://zendesk.example.com/tickets/${ticketId}`  // plain string also works
+      ],
+    },
+  },
+)
+```
+
+### Out of Scope
+
+HITLy does **not** support:
+- File attachments (declared via `attachments`, but fetch/upload is not implemented)
+- Proxying or virus-scanning remote URLs
+- SSO or authentication to remote pages
+- Assigning work items based on external URL patterns
 
 ## Evidence Storage
 

--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -1,22 +1,24 @@
-# Hitly + Mastra demo
+# HITLy + Mastra demo
 
 Two human-in-the-loop examples you can run in [Mastra Studio](https://mastra.ai/docs/studio/overview) (`mastra dev`, http://localhost:4111):
 
-1. **Refund agent** — chat with the agent. When it calls `send-refund`, the tool notifies Hitly and `suspend()`s until a reviewer decides. The tool accepts `contextMarkdown`, `externalUrls`, and declared `attachments` (PDF upload later); if markdown is omitted it sends `Refund of {amount} for {orderId}.`
-2. **Refund workflow** — run the workflow from Studio. The `hitly-approval` step notifies Hitly and suspends; reject maps to `bail()`.
+1. **Refund agent** — chat with the agent. When it calls `send-refund`, the tool notifies HITLy and `suspend()`s until a reviewer decides. The tool accepts `contextMarkdown`, `externalUrls` (with optional labels: `{ url, label? }`), and declared `attachments` (PDF upload later); if markdown is omitted it sends `Refund of {amount} for {orderId}.`
+2. **Refund workflow** — run the workflow from Studio. The `hitly-approval` step notifies HITLy and suspends; reject maps to `bail()`.
 
 ## Setup
 
-1. Start Hitly (`yarn db:up`, `yarn db:migrate`, `yarn dev:app`) and create a Mastra project. Copy the project id and API key from the project page.
-2. Copy `.env.example` to `.env` and set `HITLY_API_KEY`, `HITLY_PROJECT_ID`, and `HITLY_RESUME_SECRET` (from the Hitly project Config page). Zod `resumeSchema` uses `.passthrough()` so the signed `hitly` proof is not stripped on resume.
-3. Point the Hitly project origin base URL at `http://localhost:4111` (or set `MASTRA_BASE_URL`).
+1. Start HITLy (`yarn db:up`, `yarn db:migrate`, `yarn dev:app`) and create a Mastra project. Copy the project id and API key from the project page.
+2. Copy `.env.example` to `.env` and set `HITLY_API_KEY`, `HITLY_PROJECT_ID`, and `HITLY_RESUME_SECRET` (from the HITLy project Config page). Zod `resumeSchema` uses `.passthrough()` so the signed `hitly` proof is not stripped on resume.
+3. Point the HITLy project origin base URL at `http://localhost:4111` (or set `MASTRA_BASE_URL`).
 4. Confirm the OpenAI-compatible server is up at `OPENAI_BASE_URL`.
 
 ```bash
 yarn dev:mastra
 ```
 
-Open Studio at http://localhost:4111. Chat with **Refund Agent**, or run **refund-workflow** with `{ "orderId": "1842", "amount": 42.5 }`. Approve in the Hitly inbox at http://localhost:3001/inbox.
+Open Studio at http://localhost:4111. Chat with **Refund Agent**, or run **refund-workflow** with `{ "orderId": "1842", "amount": 42.5 }`. Approve in the HITLy inbox at http://localhost:3001/inbox.
+
+For more on envelope fields and decision context URLs, see [hitly.net/docs](https://hitly.net/docs).
 
 The local model defaults:
 

--- a/examples/mastra/src/mastra/hitly.ts
+++ b/examples/mastra/src/mastra/hitly.ts
@@ -1,5 +1,5 @@
 import { notifyHitlyApproval, type HitlyApprovalStepConfig } from '@hitly/plugin-mastra'
-import type { ApprovalAttachment } from '@hitly/core'
+import type { ApprovalAttachment, ExternalLink } from '@hitly/core'
 
 export function hitlyConfig(): Pick<
   HitlyApprovalStepConfig,
@@ -9,7 +9,7 @@ export function hitlyConfig(): Pick<
   const projectId = process.env.HITLY_PROJECT_ID ?? ''
   if (!apiKey || !projectId) {
     throw new Error(
-      'Set HITLY_API_KEY and HITLY_PROJECT_ID in examples/mastra/.env (copy them from the Hitly project page).',
+      'Set HITLY_API_KEY and HITLY_PROJECT_ID in examples/mastra/.env (copy them from the HITLy project page).',
     )
   }
   return {
@@ -24,7 +24,7 @@ export async function notifyHitly(args: {
   config: Omit<HitlyApprovalStepConfig, 'apiUrl' | 'apiKey' | 'projectId' | 'mastraBaseUrl'>
   runId: string
   contextMarkdown: string
-  externalUrls?: string[]
+  externalUrls?: Array<string | ExternalLink>
   attachments?: ApprovalAttachment[]
 }) {
   await notifyHitlyApproval(

--- a/examples/mastra/src/mastra/tools/send-refund-tool.ts
+++ b/examples/mastra/src/mastra/tools/send-refund-tool.ts
@@ -10,12 +10,22 @@ const refundInputSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Markdown brief for the Hitly reviewer. Omit to use the default one-line summary. Prefer a longer explanation: why the refund, customer/order facts, and any policy notes.',
+      'Markdown brief for the HITLy reviewer. Omit to use the default one-line summary. Prefer a longer explanation: why the refund, customer/order facts, and any policy notes.',
     ),
   externalUrls: z
-    .array(z.string())
+    .array(
+      z.union([
+        z.string(),
+        z.object({
+          url: z.string(),
+          label: z.string().optional(),
+        }),
+      ]),
+    )
     .optional()
-    .describe('Links the reviewer should open (order, ticket, policy). Use full https URLs.'),
+    .describe(
+      'Links the reviewer should open (order, ticket, policy). Use full https URLs. May include optional label: { url: "...", label: "Order #123" }',
+    ),
   attachments: z
     .array(
       z.object({
@@ -25,7 +35,7 @@ const refundInputSchema = z.object({
       }),
     )
     .optional()
-    .describe('Declared files for the reviewer. Hitly does not fetch attachments yet; pass a name (and url if you have one).'),
+    .describe('Declared files for the reviewer. HITLy does not fetch attachments yet; pass a name (and url if you have one).'),
 })
 
 type AgentToolContext = {
@@ -63,7 +73,9 @@ export const sendRefundTool = createTool({
     const orderId = resumeData?.orderId ?? inputData.orderId
     const amount = resumeData?.amount ?? inputData.amount
     const contextMarkdown = inputData.contextMarkdown?.trim() || `Refund of ${amount} for ${orderId}.`
-    const externalUrls = inputData.externalUrls?.map((url) => url.trim()).filter(Boolean)
+    const externalUrls = inputData.externalUrls
+      ?.map((item) => (typeof item === 'string' ? item.trim() : item.url.trim() ? item : null))
+      .filter(Boolean) as Array<string | { url: string; label?: string }> | undefined
     const attachments = inputData.attachments?.filter((file) => file.name.trim())
 
     if (resumeData) {

--- a/packages/core/src/evidence.ts
+++ b/packages/core/src/evidence.ts
@@ -83,6 +83,7 @@ export interface EvidenceEvent {
   toolName?: string
   sensitivity?: string[]
   dataCategories?: string[]
+  externalUrls?: Array<{ url: string; label?: string }>
 }
 
 export interface AppendReceipt {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,11 @@ export interface ApprovalAttachment {
   contentType?: string
 }
 
+export interface ExternalLink {
+  url: string
+  label?: string
+}
+
 export interface EditableFieldSpec {
   type: 'string' | 'int' | 'float' | 'bool' | 'enum' | 'array'
   label?: string
@@ -81,8 +86,8 @@ export interface ApprovalEnvelope {
   contextMarkdown?: string
   /** Opaque origin bag. HTTP echoes this unchanged on accept and reject. */
   metadata?: Record<string, unknown>
-  /** Reviewer links from the origin (tickets, orders, policies). */
-  externalUrls?: string[]
+  /** Reviewer links from the origin (tickets, orders, policies). Each link has a required url and optional label. */
+  externalUrls?: ExternalLink[]
   /** Declared files for the reviewer. Fetch/upload is not implemented yet. */
   attachments?: ApprovalAttachment[]
   resumeSchema?: Record<string, unknown>
@@ -206,6 +211,22 @@ export function isChannelType(value: unknown): value is ChannelType {
 
 export function allowedActionsFor(partial?: Partial<AllowedActions>): AllowedActions {
   return { ...DEFAULT_ALLOWED_ACTIONS, ...partial }
+}
+
+export function normalizeExternalLinks(externalUrls?: string[] | ExternalLink[]): ExternalLink[] {
+  if (!externalUrls || externalUrls.length === 0) return []
+  return externalUrls
+    .map((item) => {
+      if (typeof item === 'string') {
+        return { url: item.trim() }
+      }
+      const normalized: ExternalLink = { url: item.url.trim() }
+      if (item.label?.trim()) {
+        normalized.label = item.label.trim()
+      }
+      return normalized
+    })
+    .filter((link) => link.url)
 }
 
 export function isWorkspaceAdmin(role: WorkspaceRole): boolean {

--- a/packages/plugin-http/src/index.ts
+++ b/packages/plugin-http/src/index.ts
@@ -3,6 +3,7 @@ import {
   type ApprovalEnvelope,
   type ConnectionCredentials,
   type DecisionPayload,
+  type ExternalLink,
   type HitlyPlugin,
   type OriginRef,
   type ResumeResponse,
@@ -16,6 +17,24 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {}
+}
+
+function externalLinkList(value: unknown): ExternalLink[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const out: ExternalLink[] = []
+  for (const item of value) {
+    if (typeof item === 'string' && item.trim()) {
+      out.push({ url: item.trim() })
+    } else if (item && typeof item === 'object') {
+      const record = asRecord(item)
+      const url = optionalString(record.url)
+      if (url) {
+        const label = optionalString(record.label)
+        out.push(label ? { url, label } : { url })
+      }
+    }
+  }
+  return out.length > 0 ? out : undefined
 }
 
 /**
@@ -55,6 +74,7 @@ export const httpPlugin: HitlyPlugin = {
       },
       allowedActions: allowedActionsFor(allowedActionsPartial ?? { accept: true, reject: true }),
       contextMarkdown: typeof body.contextMarkdown === 'string' ? body.contextMarkdown : undefined,
+      externalUrls: externalLinkList(body.externalUrls),
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
       editableFields: editableFields as any,
       editReason: editReason as any,

--- a/packages/plugin-mastra/src/index.ts
+++ b/packages/plugin-mastra/src/index.ts
@@ -4,6 +4,7 @@ import {
   type ApprovalEnvelope,
   type ConnectionCredentials,
   type DecisionPayload,
+  type ExternalLink,
   type HitlyPlugin,
   type OriginRef,
   type ResumeResponse,
@@ -92,6 +93,24 @@ function attachmentList(value: unknown): ApprovalAttachment[] | undefined {
       url: optionalString(record.url),
       contentType: optionalString(record.contentType),
     })
+  }
+  return out.length > 0 ? out : undefined
+}
+
+function externalLinkList(value: unknown): ExternalLink[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const out: ExternalLink[] = []
+  for (const item of value) {
+    if (typeof item === 'string' && item.trim()) {
+      out.push({ url: item.trim() })
+    } else if (item && typeof item === 'object') {
+      const record = asRecord(item)
+      const url = optionalString(record.url)
+      if (url) {
+        const label = optionalString(record.label)
+        out.push(label ? { url, label } : { url })
+      }
+    }
   }
   return out.length > 0 ? out : undefined
 }
@@ -245,7 +264,7 @@ export function ingestMastra(raw: unknown): ApprovalEnvelope & { origin: OriginR
       optionalString(suspendPayload.contextMarkdown) ??
       optionalString(body.contextMarkdown) ??
       optionalString(suspendPayload.reason),
-    externalUrls: stringList(suspendPayload.externalUrls) ?? stringList(body.externalUrls),
+    externalUrls: externalLinkList(suspendPayload.externalUrls) ?? externalLinkList(body.externalUrls),
     attachments: attachmentList(suspendPayload.attachments) ?? attachmentList(body.attachments),
     resumeSchema: asRecord(body.resumeSchema),
     expiresAt: typeof body.expiresAt === 'string' ? body.expiresAt : undefined,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #62

## Summary

Adds support for decision context URLs with optional labels to help reviewers make informed decisions by providing links to external resources (orders, tickets, policies, etc.).

## Changes

### Core Types & API
- Extend existing `ApprovalEnvelope.externalUrls` (was unused) to support `{ url: string; label?: string }[]`
- Maintain backward compatibility: bare strings still work, converted to `{ url, label: undefined }`
- Add `ExternalLink` type and `normalizeExternalLinks()` helper
- Persist URLs on ingest (envelope and evidence events)

### UI Components
- **Web**: Display labeled links in work item detail (`apps/app/components/context-markdown.tsx`)
- **Mobile**: Display labeled links in work item detail (`apps/mobile/src/components/detail/ContextMarkdown.tsx`)
- Links open in new tab with `rel="noopener noreferrer"`

### Plugins
- **HTTP plugin**: Parse and persist `externalUrls` with labels
- **Mastra plugin**: Parse and persist `externalUrls` from both `suspendPayload` and body
- Both plugins normalize string arrays to `ExternalLink[]` on ingest

### Examples & Documentation
- Update Mastra refund tool schema to accept labeled URLs
- Add example in envelope docs showing both string and labeled formats
- Document evidence hashing (hashes URL list and labels, not remote bytes)
- Add comprehensive section on external URLs in envelope documentation
- Update Mastra example README

### Tests
- Add comprehensive test suite (`apps/app/lib/external-links.test.ts`)
- Test `normalizeExternalLinks()` with string arrays, ExternalLink objects, mixed arrays, and edge cases
- Test plugin ingest with labeled URLs
- **Tests import production code** (`normalizeExternalLinks`, `httpPlugin`, `mastraPlugin`)

## Evidence & Compliance

Evidence events include `externalUrls` in the envelope context and hash the **URL list and labels** (by-reference metadata only), not remote page bytes. HITLy does **not** fetch, proxy, or verify remote content. The `decided` event includes the same `externalUrls` array present at ingest. Decide path remains **fail-closed**.

## Acceptance Criteria

✅ **Optional on ingest**: `externalUrls` is optional on `ApprovalEnvelope`  
✅ **Show on work item**: Links display in Context section with labels  
✅ **Hash URLs + labels on evidence**: Evidence events include the URL/label array  
✅ **No outbound GET**: HITLy does not fetch remote URLs  
✅ **Decide stays fail-closed**: Decision path unchanged  
✅ **Persist on ingest**: URLs stored on approval envelope (not dropped)  
✅ **Empty list is fine**: `externalUrls: []` or omitted both work  
✅ **Tests import production code**: Tests use actual `normalizeExternalLinks`, plugins  

## Example Usage

```typescript
// Backward compatible: string arrays
externalUrls: [
  'https://shop.example.com/orders/OR-123',
  'https://zendesk.example.com/tickets/TK-456'
]

// Recommended: with labels
externalUrls: [
  { url: 'https://shop.example.com/orders/OR-123', label: 'Order #123' },
  { url: 'https://zendesk.example.com/tickets/TK-456', label: 'Support Ticket' },
  { url: 'https://shop.example.com/policies/refund' }  // label optional
]
```

## Partner Path

Clone the repo, run `yarn install && yarn db:up && yarn db:migrate`, start the Mastra example with `yarn dev:mastra`, and test at `http://localhost:3001` (never `cloud-test.hitly.net`).

## Testing

```bash
yarn typecheck  # ✅ All packages pass
yarn workspace @hitly/app tsx --test lib/external-links.test.ts  # ✅ All 8 tests pass
```

## Out of Scope

- File attachments (declared via `attachments`, but fetch/upload not implemented)
- Proxying or virus-scanning remote URLs
- SSO or authentication to remote pages
- Assignment rules based on external URL patterns
- New plugin or origin framework
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af466c3f-7547-49a6-b269-3e36f7953f58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af466c3f-7547-49a6-b269-3e36f7953f58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

